### PR TITLE
fix(test): fix network-p2p test failed

### DIFF
--- a/network-libp2p/src/config.rs
+++ b/network-libp2p/src/config.rs
@@ -58,7 +58,7 @@ impl Default for NetworkConfiguration {
             listen_addresses: Vec::new(),
             public_addresses: Vec::new(),
             boot_nodes: Vec::new(),
-            node_key: NodeKeyConfig::Secp256k1(Secret::New),
+            node_key: NodeKeyConfig::Ed25519(Secret::New),
             in_peers: 25,
             out_peers: 75,
             reserved_nodes: Vec::new(),


### PR DESCRIPTION
PeerId cannot derived from PublicKey::Secp256k1