### PR TITLE
chore: remove useless println in network test

### DIFF
--- a/sgnetwork/src/tests.rs
+++ b/sgnetwork/src/tests.rs
@@ -134,10 +134,7 @@ mod tests {
                     Err(_e) => Err(()),
                 }
             });
-        let receive_fut = rx1.for_each(|msg| {
-            println!("{:?}", msg);
-            Ok(())
-        });
+        let receive_fut = rx1.for_each(|_| Ok(()));
         executor.spawn(receive_fut);
         rt.executor().spawn(sender_fut);
         let task = Delay::new(Instant::now() + Duration::from_secs(6))


### PR DESCRIPTION
remove this to prevent useless output duing test.