### PR TITLE
feature: wallet save pending txn

### DIFF
--- a/sgtypes/src/channel_transaction_to_commit.rs
+++ b/sgtypes/src/channel_transaction_to_commit.rs
@@ -12,9 +12,8 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ChannelTransactionToApply {
     pub signed_channel_txn: SignedChannelTransaction,
-    pub travel: bool,
     /// tx output related
-    pub write_set: WriteSet,
+    pub write_set: Option<WriteSet>,
     // other tx output fields for later usage
     pub events: Vec<ContractEvent>,
     pub major_status: StatusCode,

--- a/sgwallet/src/channel.rs
+++ b/sgwallet/src/channel.rs
@@ -3,10 +3,17 @@
 
 use crate::channel_state_view::ChannelStateView;
 use crate::tx_applier::TxApplier;
+use crate::wallet::{
+    execute_transaction, get_channel_transaction_payload_body, txn_expiration, WalletInner,
+    GAS_UNIT_PRICE, MAX_GAS_AMOUNT_ONCHAIN,
+};
 use atomic_refcell::AtomicRefCell;
 use failure::prelude::*;
-use libra_crypto::HashValue;
-use libra_types::transaction::Version;
+use libra_crypto::{hash::CryptoHash, HashValue, VerifyingKey};
+use libra_logger::prelude::*;
+use libra_types::transaction::{
+    ChannelTransactionPayload, ChannelWriteSetBody, RawTransaction, TransactionArgument, Version,
+};
 use libra_types::write_set::WriteSet;
 use libra_types::{
     access_path::{AccessPath, DataPath},
@@ -19,8 +26,10 @@ use sgchain::star_chain_client::ChainClient;
 use sgstorage::channel_db::ChannelDB;
 use sgstorage::channel_store::ChannelStore;
 use sgtypes::channel::ChannelInfo;
-use sgtypes::channel_transaction::ChannelTransaction;
-use sgtypes::channel_transaction_sigs::ChannelTransactionSigs;
+use sgtypes::channel_transaction::{
+    ChannelOp, ChannelTransaction, ChannelTransactionRequest, ChannelTransactionResponse,
+};
+use sgtypes::channel_transaction_sigs::{ChannelTransactionSigs, TxnSignature};
 use sgtypes::channel_transaction_to_commit::ChannelTransactionToApply;
 use sgtypes::signed_channel_transaction::SignedChannelTransaction;
 use sgtypes::signed_channel_transaction_with_proof::SignedChannelTransactionWithProof;
@@ -28,6 +37,7 @@ use sgtypes::{
     channel::{ChannelStage, ChannelState},
     sg_error::SgError,
 };
+use vm::gas_schedule::GasAlgebra;
 
 #[derive(Debug)]
 pub struct Channel {
@@ -132,6 +142,294 @@ impl Channel {
                 }
             }
         }
+    }
+
+    // TODO(caojiafeng): once actor model is used, we don't need to pass the wallet through method.
+    pub fn execute<C: ChainClient + Send + Sync + 'static>(
+        &self,
+        wallet: &WalletInner<C>,
+        channel_op: ChannelOp,
+        args: Vec<TransactionArgument>,
+    ) -> Result<ChannelTransactionRequest> {
+        let state_view = self.channel_view(None, wallet.client())?;
+
+        // build channel_transaction first
+        let channel_transaction = ChannelTransaction::new(
+            state_view.version(),
+            channel_op,
+            self.account().address(),
+            wallet.sequence_number()?,
+            self.participant.address(),
+            self.channel_sequence_number(),
+            txn_expiration(),
+            args,
+        );
+
+        // create mocked txn to execute
+        let txn =
+            wallet.create_mocked_signed_script_txn(self.witness_data(), &channel_transaction)?;
+        let output = execute_transaction(&state_view, txn.clone())?;
+
+        // check output gas
+        let gas_used = output.gas_used();
+        if gas_used > vm::gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS.get() {
+            warn!(
+                "GasUsed {} > gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS {}",
+                gas_used,
+                vm::gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS.get()
+            );
+        }
+
+        let channel_write_set = ChannelWriteSetBody::new(
+            channel_transaction.channel_sequence_number(),
+            output.write_set().clone(),
+            channel_transaction.sender(),
+        );
+        let channel_write_set_hash = channel_write_set.hash();
+        let channel_write_set_signature = wallet.sign_message(&channel_write_set_hash);
+        let channel_txn_hash = channel_transaction.hash();
+        let channel_txn_signature = wallet.sign_message(&channel_txn_hash);
+
+        let channel_txn_sigs = ChannelTransactionSigs::new(
+            wallet.public_key().clone(),
+            TxnSignature::SenderSig {
+                channel_txn_signature,
+            },
+            channel_write_set_hash,
+            channel_write_set_signature,
+        );
+
+        let channel_txn_request = ChannelTransactionRequest::new(
+            channel_transaction.clone(),
+            channel_txn_sigs.clone(),
+            output.is_travel_txn(),
+        );
+
+        // we need to save the pending txn, in case node nown
+        self.save_pending_txn(
+            PendingTransaction::WaitForReceiverSig {
+                request_id: channel_txn_request.request_id(),
+                raw_tx: channel_transaction,
+                output,
+                sender_sigs: channel_txn_sigs,
+            },
+            true,
+        )?;
+
+        Ok(channel_txn_request)
+    }
+    /// called by reciever to verify sender's channel_txn.
+    fn verify_channel_txn(
+        &self,
+        channel_txn: &ChannelTransaction,
+        channel_txn_sigs: &ChannelTransactionSigs,
+    ) -> Result<()> {
+        let channel_sequence_number = self.channel_sequence_number();
+        ensure!(
+            channel_sequence_number == channel_txn.channel_sequence_number(),
+            "check channel_sequence_number fail."
+        );
+        match &channel_txn_sigs.signature {
+            TxnSignature::SenderSig {
+                channel_txn_signature,
+            } => {
+                channel_txn_sigs
+                    .public_key
+                    .verify_signature(&channel_txn.hash(), channel_txn_signature)?;
+            }
+            _ => bail!("not support"),
+        }
+        //TODO check public_key match with sender address.
+        Ok(())
+    }
+    // called by both of sender and reciver, to verify participant's witness payload
+    fn verify_channel_witness(
+        &self,
+        output: &TransactionOutput,
+        channel_txn_sigs: &ChannelTransactionSigs,
+    ) -> Result<ChannelTransactionPayload> {
+        let write_set_body = ChannelWriteSetBody::new(
+            self.channel_sequence_number(),
+            output.write_set().clone(),
+            self.participant().address(),
+        );
+        let write_set_body_hash = write_set_body.hash();
+        ensure!(
+            write_set_body_hash == channel_txn_sigs.write_set_payload_hash.clone(),
+            "channel output hash mismatched"
+        );
+        channel_txn_sigs.public_key.verify_signature(
+            &write_set_body_hash,
+            &channel_txn_sigs.write_set_payload_signature,
+        )?;
+
+        Ok(ChannelTransactionPayload::new_with_write_set(
+            write_set_body,
+            channel_txn_sigs.public_key.clone(),
+            channel_txn_sigs.write_set_payload_signature.clone(),
+        ))
+    }
+
+    /// called by sender, to verify receiver's response
+    fn verify_response<C: ChainClient + Send + Sync + 'static>(
+        &self,
+        wallet: &WalletInner<C>,
+        channel_txn: &ChannelTransaction,
+        output: &TransactionOutput,
+        receiver_sigs: &ChannelTransactionSigs,
+    ) -> Result<(ChannelTransactionPayload, ChannelTransactionPayload)> {
+        let channel_txn_sigs = receiver_sigs;
+
+        let raw_txn =
+            wallet.build_raw_txn_from_channel_txn(self.witness_data(), channel_txn, None)?;
+
+        // verify receiver's channel txn payload signature
+        let verified_channel_txn_payload = match &channel_txn_sigs.signature {
+            TxnSignature::ReceiverSig {
+                channel_script_body_signature,
+            } => {
+                let channel_payload = get_channel_transaction_payload_body(&raw_txn)?;
+                channel_payload
+                    .verify(&channel_txn_sigs.public_key, channel_script_body_signature)?;
+                ChannelTransactionPayload::new(
+                    channel_payload,
+                    channel_txn_sigs.public_key.clone(),
+                    channel_script_body_signature.clone(),
+                )
+            }
+            _ => bail!("should not happen"),
+        };
+
+        let verified_participant_witness_payload =
+            self.verify_channel_witness(&output, channel_txn_sigs)?;
+        Ok((
+            verified_channel_txn_payload,
+            verified_participant_witness_payload,
+        ))
+    }
+
+    pub fn verify_txn_request<C: ChainClient + Send + Sync + 'static>(
+        &self,
+        wallet: &WalletInner<C>,
+        txn_request: &ChannelTransactionRequest,
+    ) -> Result<ChannelTransactionResponse> {
+        let request_id = txn_request.request_id();
+        let channel_txn = txn_request.channel_txn();
+        let channel_txn_sender_sigs = txn_request.channel_txn_sigs();
+
+        self.verify_channel_txn(channel_txn, channel_txn_sender_sigs)?;
+
+        let signed_txn =
+            wallet.create_mocked_signed_script_txn(self.witness_data(), channel_txn)?;
+        let txn_payload_signature = signed_txn
+            .receiver_signature()
+            .expect("signature must exist.");
+
+        let version = channel_txn.version();
+        let output = {
+            let state_view = self.channel_view(Some(version), wallet.client())?;
+            execute_transaction(&state_view, signed_txn)?
+        };
+
+        let _verified_participant_witness_payload =
+            self.verify_channel_witness(&output, channel_txn_sender_sigs)?;
+
+        // build signatures sent to sender
+        let write_set_body = ChannelWriteSetBody::new(
+            self.channel_sequence_number(),
+            output.write_set().clone(),
+            self.account().address(),
+        );
+        let witness_hash = write_set_body.hash();
+        let witness_signature = wallet.sign_message(&witness_hash);
+
+        let channel_txn_receiver_sigs = ChannelTransactionSigs::new(
+            wallet.public_key().clone(),
+            TxnSignature::ReceiverSig {
+                channel_script_body_signature: txn_payload_signature,
+            },
+            witness_hash,
+            witness_signature,
+        );
+
+        // if it's a travel txn, we need to persist the pending apply txn before reply to sender.
+        // just in case that the node is down after sending reply to sender.
+        // in this case, if it's not saved, receiver has no way to get channel_txn from onchain txn,
+        // if it's offchain, there is no need. because:
+        // - if sender receive the msg from receiver, receiver can sync it from sender.
+        // - if sender doesn't receive the msg, sender will resend the request to receiver, as if nothing happens.
+
+        {
+            let should_persist = output.is_travel_txn();
+            self.save_pending_txn(
+                PendingTransaction::WaitForApply {
+                    request_id,
+                    raw_tx: channel_txn.clone(),
+                    sender_sigs: channel_txn_sender_sigs.clone(),
+                    receiver_sigs: channel_txn_receiver_sigs.clone(),
+                    output,
+                },
+                should_persist,
+            )?;
+        }
+
+        Ok(ChannelTransactionResponse::new(
+            request_id,
+            channel_txn_receiver_sigs,
+        ))
+    }
+
+    pub fn verify_txn_response<C: ChainClient + Send + Sync + 'static>(
+        &self,
+        wallet: &WalletInner<C>,
+        response: &ChannelTransactionResponse,
+    ) -> Result<(ChannelTransactionPayload, ChannelTransactionPayload)> {
+        let (request_id, channel_txn, output, sender_sigs) = match self.pending_txn() {
+            Some(PendingTransaction::WaitForReceiverSig {
+                request_id,
+                raw_tx,
+                output,
+                sender_sigs,
+            }) => (request_id, raw_tx, output, sender_sigs),
+            //TODO(jole) can not find request has such reason:
+            // 1. txn is expire.
+            // 2. txn is invalid.
+            _ => bail!("invalid state when sender apply txn"),
+        };
+
+        ensure!(
+            request_id == response.request_id(),
+            "request id mismatch, request: {}, response: {}",
+            request_id,
+            response.request_id()
+        );
+
+        info!("verify channel response: {}", response.request_id());
+        let (verified_participant_script_payload, verified_participant_witness_payload) =
+            self.verify_response(&wallet, &channel_txn, &output, response.channel_txn_sigs())?;
+
+        let _gas_used = output.gas_used();
+        let is_travel = output.is_travel_txn();
+
+        // if it's a travel txn, we need to save the pending apply txn before submit to layer1.
+        // just in case that the node is down after submit.
+        // in this case, if it's not saved, receiver has no way to get channel_txn from onchain txn,
+        // if it's offchain, there is no need. because:
+        // - sender will resend the txn to receiver, and receiver will reply the msg.
+        self.save_pending_txn(
+            PendingTransaction::WaitForApply {
+                request_id,
+                raw_tx: channel_txn.clone(),
+                sender_sigs: sender_sigs.clone(),
+                receiver_sigs: response.channel_txn_sigs().clone(),
+                output,
+            },
+            is_travel,
+        )?;
+        Ok((
+            verified_participant_script_payload,
+            verified_participant_witness_payload,
+        ))
     }
 
     /// apply data into local channel storage
@@ -332,4 +630,30 @@ impl PendingState {
         *self.cache.borrow_mut() = Some(pending);
         Ok(())
     }
+}
+
+pub fn pending_txn_to_onchain_txn(
+    pending_txn: PendingTransaction,
+    verified_participant_script_payload: ChannelTransactionPayload,
+) -> Result<Option<RawTransaction>> {
+    let (channel_txn, output) = match pending_txn {
+        PendingTransaction::WaitForApply { raw_tx, output, .. } => (raw_tx, output),
+        _ => bail!("invalid state when apply to onchain"),
+    };
+
+    let gas_used = output.gas_used();
+    if !output.is_travel_txn() {
+        return Ok(None);
+    }
+    // construct onchain tx
+    let max_gas_amount = std::cmp::min((gas_used as f64 * 1.1) as u64, MAX_GAS_AMOUNT_ONCHAIN);
+    let new_raw_txn = RawTransaction::new_channel(
+        channel_txn.sender(),
+        channel_txn.sequence_number(),
+        verified_participant_script_payload,
+        max_gas_amount,
+        GAS_UNIT_PRICE,
+        channel_txn.expiration_time(),
+    );
+    Ok(Some(new_raw_txn))
 }

--- a/sgwallet/src/tests/channel_test.rs
+++ b/sgwallet/src/tests/channel_test.rs
@@ -12,6 +12,6 @@ fn test_channel_get_txn() {
     let _channel = Channel::new(
         store.db().owner_address(),
         store.db().participant_address(),
-        store,
+        store.db(),
     );
 }

--- a/sgwallet/src/tests/mod.rs
+++ b/sgwallet/src/tests/mod.rs
@@ -70,8 +70,7 @@ fn generate_txn_to_apply(
                 signature.clone(),
             ),
         },
-        write_set: ws,
-        travel: false,
+        write_set: Some(ws),
         events: vec![],
         major_status: StatusCode::ABORTED,
     };

--- a/sgwallet/src/tx_applier.rs
+++ b/sgwallet/src/tx_applier.rs
@@ -135,14 +135,15 @@ impl TxApplier {
             write_set,
             events,
             major_status,
-            travel,
+            ..
         } = tx_to_apply;
         let channel_seq_number = signed_channel_txn.raw_tx.channel_sequence_number();
         ensure!(
             channel_seq_number == self.applied_trees.tx_accumulator.num_leaves(),
             "tx channel seq number mismatched"
         );
-        let witness_states = self.process_write_set(&write_set, travel)?;
+
+        let witness_states = self.process_write_set(write_set.as_ref())?;
 
         let new_state_tree = Self::build_state_tree(
             &witness_states,
@@ -151,6 +152,12 @@ impl TxApplier {
         )?;
         let _event_tree = InMemoryAccumulator::<EventAccumulatorHasher>::default()
             .append(events.iter().map(CryptoHash::hash).collect_vec().as_slice());
+
+        let (travel, write_set) = match write_set {
+            None => (true, WriteSet::default()),
+            Some(ws) => (false, ws),
+        };
+
         let write_set_tree = InMemoryAccumulator::<WriteSetAccumulatorHasher>::default().append(
             write_set
                 .iter()
@@ -304,37 +311,35 @@ impl TxApplier {
 
     fn process_write_set(
         &self,
-        write_set: &WriteSet,
-        travel: bool,
+        write_set: Option<&WriteSet>,
     ) -> Result<BTreeMap<AccountAddress, AccountStateBlob>> {
-        // if write_set is empty, it means the upper channel tx is travel
-        if travel {
-            ensure!(
-                write_set.is_empty(),
-                "write set should be empty if channel tx is travel"
-            );
-            let mut state = BTreeMap::new();
-            let empty_state_blob = AccountStateBlob::try_from(&BTreeMap::new())?;
-            state.insert(self.owner_address(), empty_state_blob.clone());
-            state.insert(self.participant_address(), empty_state_blob);
-            Ok(state)
-        } else {
-            ensure!(
-                !write_set.is_empty(),
-                "write set should not be empty if channel tx is offchain"
-            );
-            let state: BTreeMap<AccountAddress, BTreeMap<Vec<u8>, Vec<u8>>> =
-                write_set.try_into()?;
-            let mut blob_state = BTreeMap::new();
-            for (addr, state_btree) in state.into_iter() {
-                blob_state.insert(addr, AccountStateBlob::try_from(&state_btree)?);
+        // if write_set is none, it means the upper channel tx is travel
+        match write_set {
+            None => {
+                let mut state = BTreeMap::new();
+                let empty_state_blob = AccountStateBlob::try_from(&BTreeMap::new())?;
+                state.insert(self.owner_address(), empty_state_blob.clone());
+                state.insert(self.participant_address(), empty_state_blob);
+                Ok(state)
             }
-            check_witness_state(
-                self.owner_address(),
-                self.participant_address(),
-                &blob_state,
-            )?;
-            Ok(blob_state)
+            Some(write_set) => {
+                ensure!(
+                    !write_set.is_empty(),
+                    "write set should not be empty if channel tx is offchain"
+                );
+                let state: BTreeMap<AccountAddress, BTreeMap<Vec<u8>, Vec<u8>>> =
+                    write_set.try_into()?;
+                let mut blob_state = BTreeMap::new();
+                for (addr, state_btree) in state.into_iter() {
+                    blob_state.insert(addr, AccountStateBlob::try_from(&state_btree)?);
+                }
+                check_witness_state(
+                    self.owner_address(),
+                    self.participant_address(),
+                    &blob_state,
+                )?;
+                Ok(blob_state)
+            }
         }
     }
 }

--- a/sgwallet/src/wallet.rs
+++ b/sgwallet/src/wallet.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::channel::PendingTransaction;
+use crate::channel::{pending_txn_to_onchain_txn, PendingTransaction};
 use crate::{channel::Channel, scripts::*};
 use chrono::Utc;
 use failure::prelude::*;
@@ -11,12 +11,13 @@ use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     hash::CryptoHash,
     test_utils::KeyPair,
-    SigningKey, VerifyingKey,
+    HashValue, SigningKey, VerifyingKey,
 };
 use libra_logger::prelude::*;
 use libra_state_view::StateView;
 use libra_types::access_path::AccessPath;
 use libra_types::transaction::Transaction;
+use libra_types::write_set::WriteSet;
 use libra_types::{
     access_path::DataPath,
     account_address::AccountAddress,
@@ -25,10 +26,9 @@ use libra_types::{
     language_storage::StructTag,
     transaction::{
         helpers::{create_signed_payload_txn, ChannelPayloadSigner, TransactionSigner},
-        ChannelScriptBody, ChannelTransactionPayload, ChannelTransactionPayloadBody,
-        ChannelWriteSetBody, Module, RawTransaction, Script, SignedTransaction,
-        TransactionArgument, TransactionOutput, TransactionPayload, TransactionStatus,
-        TransactionWithProof,
+        ChannelScriptBody, ChannelTransactionPayload, ChannelTransactionPayloadBody, Module,
+        RawTransaction, Script, SignedTransaction, TransactionArgument, TransactionOutput,
+        TransactionPayload, TransactionStatus, TransactionWithProof,
     },
     vm_error::*,
 };
@@ -37,7 +37,6 @@ use sgconfig::config::WalletConfig;
 use sgstorage::channel_db::ChannelDB;
 use sgstorage::storage::SgStorage;
 use sgtypes::channel::ChannelInfo;
-use sgtypes::channel_transaction_sigs::{ChannelTransactionSigs, TxnSignature};
 use sgtypes::sg_error::SgError;
 use sgtypes::signed_channel_transaction::SignedChannelTransaction;
 use sgtypes::{
@@ -53,7 +52,6 @@ use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::sync::RwLock;
 use std::{sync::Arc, time::Duration};
-use vm::gas_schedule::GasAlgebra;
 use vm_runtime::{MoveVM, VMExecutor};
 
 lazy_static! {
@@ -61,14 +59,17 @@ lazy_static! {
     static ref VM_CONFIG: VMConfig = VMConfig::offchain();
 }
 
+// const RETRY_INTERVAL: u64 = 1000;
+const TXN_EXPIRATION: Duration = Duration::from_secs(24 * 60 * 60);
+pub(crate) const MAX_GAS_AMOUNT_OFFCHAIN: u64 = std::u64::MAX;
+pub(crate) const MAX_GAS_AMOUNT_ONCHAIN: u64 = 1_000_000;
+pub(crate) const GAS_UNIT_PRICE: u64 = 1;
+
 pub struct Wallet<C>
 where
     C: ChainClient + Send + Sync + 'static,
 {
-    account: AccountAddress,
-    keypair: Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
-    client: Arc<C>,
-    script_registry: PackageRegistry,
+    inner: WalletInner<C>,
     channels: RwLock<HashMap<AccountAddress, Channel>>,
     sgdb: Arc<SgStorage>,
 }
@@ -77,12 +78,6 @@ impl<C> Wallet<C>
 where
     C: ChainClient + Send + Sync + 'static,
 {
-    const TXN_EXPIRATION: Duration = Duration::from_secs(24 * 60 * 60);
-    const MAX_GAS_AMOUNT_OFFCHAIN: u64 = std::u64::MAX;
-    const MAX_GAS_AMOUNT_ONCHAIN: u64 = 1_000_000;
-    const GAS_UNIT_PRICE: u64 = 1;
-    // const RETRY_INTERVAL: u64 = 1000;
-
     pub fn new(
         account: AccountAddress,
         keypair: Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
@@ -102,12 +97,15 @@ where
     ) -> Result<Self> {
         let sgdb = Arc::new(SgStorage::new(account, store_dir));
 
-        let script_registry = PackageRegistry::build()?;
-        let mut wallet = Self {
+        let script_registry = Arc::new(PackageRegistry::build()?);
+        let inner = WalletInner {
             account,
             keypair,
             client,
             script_registry,
+        };
+        let mut wallet = Self {
+            inner,
             channels: RwLock::new(HashMap::new()),
             sgdb,
         };
@@ -116,20 +114,25 @@ where
     }
 
     fn refresh_channels(&mut self) -> Result<()> {
-        let account_state = self.client.get_account_state(self.account, None)?;
-        let my_channel_states = account_state.filter_channel_state(self.account);
+        let account_state = self
+            .inner
+            .client
+            .get_account_state(self.inner.account, None)?;
+        let my_channel_states = account_state.filter_channel_state(self.inner.account);
         let version = account_state.version();
         for (participant, my_channel_state) in my_channel_states {
             if !self.exist_channel(&participant) {
-                let participant_account_state =
-                    self.client.get_account_state(participant, Some(version))?;
+                let participant_account_state = self
+                    .inner
+                    .client
+                    .get_account_state(participant, Some(version))?;
                 let mut participant_channel_states =
                     participant_account_state.filter_channel_state(participant);
                 let participant_channel_state = participant_channel_states
-                    .remove(&self.account)
+                    .remove(&self.inner.account)
                     .ok_or(format_err!(
                         "Can not find channel {} in {}",
-                        self.account,
+                        self.inner.account,
                         participant
                     ))?;
                 let channel_db = self.get_channel_db(participant);
@@ -143,282 +146,19 @@ where
     }
 
     pub fn account(&self) -> AccountAddress {
-        self.account
+        self.inner.account
     }
 
     pub fn client(&self) -> &dyn ChainClient {
-        &*self.client
+        self.inner.client()
     }
 
     pub fn default_asset() -> StructTag {
         DEFAULT_ASSET.clone()
     }
 
-    fn execute_transaction(
-        state_view: &dyn StateView,
-        transaction: SignedTransaction,
-    ) -> Result<TransactionOutput> {
-        let tx_hash = transaction.raw_txn().hash();
-        let output = MoveVM::execute_block(
-            vec![Transaction::UserTransaction(transaction)],
-            &VM_CONFIG,
-            state_view,
-        )?
-        .pop()
-        .expect("at least return 1 output.");
-        debug!("execute txn:{} output: {}", tx_hash, output);
-        match output.status() {
-            TransactionStatus::Discard(vm_status) => {
-                bail!("transaction execute fail for: {:#?}", vm_status)
-            }
-            TransactionStatus::Keep(vm_status) => match vm_status.major_status {
-                StatusCode::EXECUTED => {
-                    //continue
-                }
-                _ => bail!("transaction execute fail for: {:#?}", vm_status),
-            },
-        };
-        Ok(output)
-    }
-
     pub fn get_resources() -> Vec<Resource> {
         unimplemented!()
-    }
-
-    fn get_channel_transaction_payload_body(
-        raw_txn: &RawTransaction,
-    ) -> Result<ChannelTransactionPayloadBody> {
-        match raw_txn.payload() {
-            TransactionPayload::Channel(payload) => Ok(payload.body.clone()),
-            _ => bail!("raw txn must a Channel Transaction"),
-        }
-    }
-
-    fn execute(
-        &self,
-        channel_op: ChannelOp,
-        receiver: AccountAddress,
-        args: Vec<TransactionArgument>,
-    ) -> Result<ChannelTransactionRequest> {
-        let channels = self.channels.read().unwrap();
-        let channel = channels
-            .deref()
-            .get(&receiver)
-            .ok_or::<Error>(SgError::new_channel_not_exist_error(&receiver).into())?;
-
-        let state_view = channel.channel_view(None, &*self.client)?;
-
-        // build channel_transaction first
-        let channel_transaction = ChannelTransaction::new(
-            state_view.version(),
-            channel_op,
-            channel.account().address(),
-            self.sequence_number()?,
-            receiver,
-            channel.channel_sequence_number(),
-            Self::txn_expiration(),
-            args,
-        );
-
-        // create mocked txn to execute
-        let txn = self.create_mocked_signed_script_txn(&channel, &channel_transaction)?;
-        let output = Self::execute_transaction(&state_view, txn.clone())?;
-
-        // check output gas
-        let gas_used = output.gas_used();
-        if gas_used > vm::gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS.get() {
-            warn!(
-                "GasUsed {} > gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS {}",
-                gas_used,
-                vm::gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS.get()
-            );
-        }
-
-        let channel_write_set = ChannelWriteSetBody::new(
-            channel_transaction.channel_sequence_number(),
-            output.write_set().clone(),
-            channel_transaction.sender(),
-        );
-        let channel_write_set_hash = channel_write_set.hash();
-        let channel_write_set_signature = self
-            .keypair
-            .private_key
-            .sign_message(&channel_write_set_hash);
-        let channel_txn_hash = channel_transaction.hash();
-        let channel_txn_signature = self.keypair.private_key.sign_message(&channel_txn_hash);
-
-        let channel_txn_sigs = ChannelTransactionSigs::new(
-            self.keypair.public_key.clone(),
-            TxnSignature::SenderSig {
-                channel_txn_signature,
-            },
-            channel_write_set_hash,
-            channel_write_set_signature,
-        );
-
-        let channel_txn_request = ChannelTransactionRequest::new(
-            channel_transaction.clone(),
-            channel_txn_sigs.clone(),
-            output.is_travel_txn(),
-        );
-
-        // we need to save the pending txn, in case node nown
-        channel.save_pending_txn(
-            PendingTransaction::WaitForReceiverSig {
-                request_id: channel_txn_request.request_id(),
-                raw_tx: channel_transaction,
-                output,
-                sender_sigs: channel_txn_sigs,
-            },
-            true,
-        )?;
-
-        Ok(channel_txn_request)
-    }
-
-    /// called by reciever to verify sender's channel_txn.
-    fn verify_channel_txn(
-        &self,
-        channel: &Channel,
-        channel_txn: &ChannelTransaction,
-        channel_txn_sigs: &ChannelTransactionSigs,
-    ) -> Result<()> {
-        let channel_sequence_number = channel.channel_sequence_number();
-        ensure!(
-            channel_sequence_number == channel_txn.channel_sequence_number(),
-            "check channel_sequence_number fail."
-        );
-        match &channel_txn_sigs.signature {
-            TxnSignature::SenderSig {
-                channel_txn_signature,
-            } => {
-                channel_txn_sigs
-                    .public_key
-                    .verify_signature(&channel_txn.hash(), channel_txn_signature)?;
-            }
-            _ => bail!("not support"),
-        }
-        //TODO check public_key match with sender address.
-        Ok(())
-    }
-
-    // called by both of sender and reciver, to verify participant's witness payload
-    fn verify_channel_witness(
-        &self,
-        channel: &Channel,
-        output: &TransactionOutput,
-        channel_txn_sigs: &ChannelTransactionSigs,
-    ) -> Result<ChannelTransactionPayload> {
-        let write_set_body = ChannelWriteSetBody::new(
-            channel.channel_sequence_number(),
-            output.write_set().clone(),
-            channel.participant().address(),
-        );
-        let write_set_body_hash = write_set_body.hash();
-        ensure!(
-            write_set_body_hash == channel_txn_sigs.write_set_payload_hash.clone(),
-            "channel output hash mismatched"
-        );
-        channel_txn_sigs.public_key.verify_signature(
-            &write_set_body_hash,
-            &channel_txn_sigs.write_set_payload_signature,
-        )?;
-
-        Ok(ChannelTransactionPayload::new_with_write_set(
-            write_set_body,
-            channel_txn_sigs.public_key.clone(),
-            channel_txn_sigs.write_set_payload_signature.clone(),
-        ))
-    }
-
-    /// Verify channel participant's txn
-    pub fn verify_txn(
-        &self,
-        txn_request: &ChannelTransactionRequest,
-    ) -> Result<ChannelTransactionResponse> {
-        let request_id = txn_request.request_id();
-        let channel_txn = txn_request.channel_txn();
-        let channel_txn_sender_sigs = txn_request.channel_txn_sigs();
-
-        // get channel
-        debug!("verify_txn id:{}", request_id);
-        ensure!(
-            channel_txn.receiver() == self.account,
-            "check receiver fail."
-        );
-        let sender = channel_txn.sender();
-        if channel_txn.operator().is_open() {
-            if self.exist_channel(&sender) {
-                bail!("Channel with address {} exist.", sender);
-            }
-            self.new_channel(sender);
-        }
-
-        let channels = self.channels.read().unwrap();
-        let channel = channels
-            .deref()
-            .get(&sender)
-            .ok_or::<Error>(SgError::new_channel_not_exist_error(&sender).into())?;
-
-        self.verify_channel_txn(&channel, channel_txn, channel_txn_sender_sigs)?;
-
-        let signed_txn = self.create_mocked_signed_script_txn(&channel, channel_txn)?;
-        let txn_payload_signature = signed_txn
-            .receiver_signature()
-            .expect("signature must exist.");
-
-        let version = channel_txn.version();
-        let output = {
-            let state_view = channel.channel_view(Some(version), &*self.client)?;
-            Self::execute_transaction(&state_view, signed_txn)?
-        };
-
-        let _verified_participant_witness_payload =
-            self.verify_channel_witness(&channel, &output, channel_txn_sender_sigs)?;
-
-        // build signatures sent to sender
-        let write_set_body = ChannelWriteSetBody::new(
-            channel.channel_sequence_number(),
-            output.write_set().clone(),
-            channel.account().address(),
-        );
-        let witness_hash = write_set_body.hash();
-        let witness_signature = self.keypair.private_key.sign_message(&witness_hash);
-
-        let channel_txn_receiver_sigs = ChannelTransactionSigs::new(
-            self.keypair.public_key.clone(),
-            TxnSignature::ReceiverSig {
-                channel_script_body_signature: txn_payload_signature,
-            },
-            witness_hash,
-            witness_signature,
-        );
-
-        // if it's a travel txn, we need to persist the pending apply txn before reply to sender.
-        // just in case that the node is down after sending reply to sender.
-        // in this case, if it's not saved, receiver has no way to get channel_txn from onchain txn,
-        // if it's offchain, there is no need. because:
-        // - if sender receive the msg from receiver, receiver can sync it from sender.
-        // - if sender doesn't receive the msg, sender will resend the request to receiver, as if nothing happens.
-
-        {
-            let should_persist = output.is_travel_txn();
-            channel.save_pending_txn(
-                PendingTransaction::WaitForApply {
-                    request_id,
-                    raw_tx: channel_txn.clone(),
-                    sender_sigs: channel_txn_sender_sigs.clone(),
-                    receiver_sigs: channel_txn_receiver_sigs.clone(),
-                    output,
-                },
-                should_persist,
-            )?;
-        }
-
-        Ok(ChannelTransactionResponse::new(
-            txn_request.request_id(),
-            channel_txn_receiver_sigs,
-        ))
     }
 
     /// Open channel and deposit default asset.
@@ -514,192 +254,6 @@ where
         self.execute(ChannelOp::Close, receiver, vec![])
     }
 
-    pub async fn receiver_apply_txn(
-        &self,
-        participant: AccountAddress,
-        response: &ChannelTransactionResponse,
-    ) -> Result<u64> {
-        let (request_id, channel_txn, output, _sender_sigs, _receiver_sigs) =
-            self.with_channel(&participant, |channel| {
-                match channel.pending_txn() {
-                    Some(PendingTransaction::WaitForApply {
-                        request_id,
-                        raw_tx,
-                        sender_sigs,
-                        receiver_sigs,
-                        output,
-                    }) => Ok((request_id, raw_tx, output, sender_sigs, receiver_sigs)),
-                    Some(_) => bail!("invalid state of receiver apply txn"),
-                    //TODO(jole) can not find request has such reason:
-                    // 1. txn is expire.
-                    // 2. txn is invalid.
-                    None => bail!(
-                        "pending_txn_request must exist at stage:{:?}",
-                        channel.stage()
-                    ),
-                }
-            })?;
-        ensure!(
-            request_id == response.request_id(),
-            "request id mismatch, request: {}, response: {}",
-            request_id,
-            response.request_id()
-        );
-
-        let gas = if !output.is_travel_txn() {
-            0
-        } else {
-            let txn_sender = channel_txn.sender();
-            let watch_future = self
-                .client
-                .watch_transaction(&txn_sender, channel_txn.sequence_number());
-            // FIXME: should not panic here, handle timeout situation.
-            let txn_with_proof = watch_future.await?.0.expect("proof is none.");
-
-            let gas = txn_with_proof.proof.transaction_info().gas_used();
-            gas
-        };
-
-        // save to db
-        self.with_channel_mut(&participant, |channel| channel.apply())?;
-
-        info!("success apply channel request: {}", request_id);
-        Ok(gas)
-    }
-
-    /// called by sender, to verify receiver's response
-    fn verify_response(
-        &self,
-        channel: &Channel,
-        channel_txn: &ChannelTransaction,
-        output: &TransactionOutput,
-        response: &ChannelTransactionResponse,
-    ) -> Result<(ChannelTransactionPayload, ChannelTransactionPayload)> {
-        info!("verify channel response: {}", response.request_id());
-        let channel_txn_sigs = response.channel_txn_sigs();
-        let verified_channel_txn_payload =
-            self.verify_channel_txn_payload(channel, channel_txn, channel_txn_sigs)?;
-        let verified_participant_witness_payload =
-            self.verify_channel_witness(channel, &output, channel_txn_sigs)?;
-        Ok((
-            verified_channel_txn_payload,
-            verified_participant_witness_payload,
-        ))
-    }
-
-    // called by sender, to verify receiver's channel txn payload signature
-    fn verify_channel_txn_payload(
-        &self,
-        channel: &Channel,
-        channel_txn: &ChannelTransaction,
-        channel_txn_sigs: &ChannelTransactionSigs,
-    ) -> Result<ChannelTransactionPayload> {
-        let raw_txn = self.build_raw_txn_from_channel_txn(channel, channel_txn, None)?;
-        let verified_channel_txn_payload = match &channel_txn_sigs.signature {
-            TxnSignature::ReceiverSig {
-                channel_script_body_signature,
-            } => {
-                let channel_payload = Self::get_channel_transaction_payload_body(&raw_txn)?;
-                channel_payload
-                    .verify(&channel_txn_sigs.public_key, channel_script_body_signature)?;
-                ChannelTransactionPayload::new(
-                    channel_payload,
-                    channel_txn_sigs.public_key.clone(),
-                    channel_script_body_signature.clone(),
-                )
-            }
-            _ => bail!("should not happen"),
-        };
-        Ok(verified_channel_txn_payload)
-    }
-
-    pub async fn sender_apply_txn(
-        &self,
-        participant: AccountAddress,
-        response: &ChannelTransactionResponse,
-    ) -> Result<u64> {
-        let (request_id, channel_txn, output, sender_sigs) =
-            self.with_channel(&participant, |channel| {
-                match channel.pending_txn() {
-                    Some(PendingTransaction::WaitForReceiverSig {
-                        request_id,
-                        raw_tx,
-                        output,
-                        sender_sigs,
-                    }) => Ok((request_id, raw_tx, output, sender_sigs)),
-                    //TODO(jole) can not find request has such reason:
-                    // 1. txn is expire.
-                    // 2. txn is invalid.
-                    _ => bail!("invalid state when sender apply txn"),
-                }
-            })?;
-
-        ensure!(
-            request_id == response.request_id(),
-            "request id mismatch, request: {}, response: {}",
-            request_id,
-            response.request_id()
-        );
-
-        let (verified_participant_script_payload, _verified_participant_witness_payload) = self
-            .with_channel(&participant, |channel| {
-                self.verify_response(&channel, &channel_txn, &output, response)
-            })?;
-
-        let gas_used = output.gas_used();
-        let is_travel = output.is_travel_txn();
-
-        // if it's a travel txn, we need to save the pending apply txn before submit to layer1.
-        // just in case that the node is down after submit.
-        // in this case, if it's not saved, receiver has no way to get channel_txn from onchain txn,
-        // if it's offchain, there is no need. because:
-        // - sender will resend the txn to receiver, and receiver will reply the msg.
-        self.with_channel_mut(&participant, |channel| {
-            channel.save_pending_txn(
-                PendingTransaction::WaitForApply {
-                    request_id,
-                    raw_tx: channel_txn.clone(),
-                    sender_sigs: sender_sigs.clone(),
-                    receiver_sigs: response.channel_txn_sigs().clone(),
-                    output,
-                },
-                is_travel,
-            )
-        })?;
-
-        let gas = if !is_travel {
-            0
-        } else {
-            // construct onchain tx
-            let max_gas_amount =
-                std::cmp::min((gas_used as f64 * 1.1) as u64, Self::MAX_GAS_AMOUNT_ONCHAIN);
-            let new_raw_txn = RawTransaction::new_channel(
-                channel_txn.sender(),
-                channel_txn.sequence_number(),
-                verified_participant_script_payload,
-                max_gas_amount,
-                Self::GAS_UNIT_PRICE,
-                channel_txn.expiration_time(),
-            );
-
-            debug!("prepare to submit txn to chain, {:?}", &new_raw_txn);
-
-            let txn_with_proof = {
-                let signed_txn = self.mock_signature(new_raw_txn)?;
-                // sender submit transaction to chain.
-                self.submit_transaction(signed_txn).await?
-            };
-            let gas = txn_with_proof.proof.transaction_info().gas_used();
-            gas
-        };
-
-        // save to db
-        self.with_channel_mut(&participant, |channel| channel.apply())?;
-
-        info!("success apply channel request: {}", request_id);
-        Ok(gas)
-    }
-
     pub fn execute_script(
         &self,
         receiver: AccountAddress,
@@ -722,9 +276,141 @@ where
         )
     }
 
+    fn execute(
+        &self,
+        channel_op: ChannelOp,
+        receiver: AccountAddress,
+        args: Vec<TransactionArgument>,
+    ) -> Result<ChannelTransactionRequest> {
+        let channels = self.channels.read().unwrap();
+        let channel = channels
+            .deref()
+            .get(&receiver)
+            .ok_or::<Error>(SgError::new_channel_not_exist_error(&receiver).into())?;
+        channel.execute(&self.inner, channel_op, args)
+    }
+
+    /// Verify channel participant's txn
+    pub fn verify_txn(
+        &self,
+        txn_request: &ChannelTransactionRequest,
+    ) -> Result<ChannelTransactionResponse> {
+        let request_id = txn_request.request_id();
+        let channel_txn = txn_request.channel_txn();
+        let _channel_txn_sender_sigs = txn_request.channel_txn_sigs();
+
+        // get channel
+        debug!("verify_txn id:{}", request_id);
+        ensure!(
+            channel_txn.receiver() == self.inner.account,
+            "check receiver fail."
+        );
+        let sender = channel_txn.sender();
+        if channel_txn.operator().is_open() {
+            if self.exist_channel(&sender) {
+                bail!("Channel with address {} exist.", sender);
+            }
+            self.new_channel(sender);
+        }
+
+        let channels = self.channels.read().unwrap();
+        let channel = channels
+            .deref()
+            .get(&sender)
+            .ok_or::<Error>(SgError::new_channel_not_exist_error(&sender).into())?;
+        channel.verify_txn_request(&self.inner, txn_request)
+    }
+
+    pub async fn receiver_apply_txn(
+        &self,
+        participant: AccountAddress,
+        response: &ChannelTransactionResponse,
+    ) -> Result<u64> {
+        let txn_to_watch = self.with_channel(&participant, |channel| {
+            let (channel_txn, output) = match channel.pending_txn() {
+                Some(PendingTransaction::WaitForApply { raw_tx, output, .. }) => (raw_tx, output),
+                Some(_) => bail!("invalid state of receiver apply txn"),
+                //TODO(jole) can not find request has such reason:
+                // 1. txn is expire.
+                // 2. txn is invalid.
+                None => bail!(
+                    "pending_txn_request must exist at stage:{:?}",
+                    channel.stage()
+                ),
+            };
+            Ok(if output.is_travel_txn() {
+                Some((channel_txn.sender(), channel_txn.sequence_number()))
+            } else {
+                None
+            })
+        })?;
+
+        let gas = match txn_to_watch {
+            Some((address, seq_number)) => {
+                let watch_future = self.inner.client().watch_transaction(&address, seq_number);
+                // FIXME: should not panic here, handle timeout situation.
+                let txn_with_proof = watch_future.await?.0.expect("proof is none.");
+
+                txn_with_proof.proof.transaction_info().gas_used()
+            }
+            None => 0,
+        };
+
+        self.with_channel_mut(&participant, |channel| channel.apply())?;
+
+        info!("success apply channel request: {}", response.request_id());
+
+        Ok(gas)
+    }
+
+    pub async fn sender_apply_txn(
+        &self,
+        participant: AccountAddress,
+        response: &ChannelTransactionResponse,
+    ) -> Result<u64> {
+        let onchain_txn_to_submit = self.with_channel(&participant, |channel| {
+            //verify response
+            let (verified_participant_script_payload, _verified_participant_witness_payload) =
+                channel.verify_txn_response(&self.inner, response)?;
+            let signed_txn = match channel.pending_txn() {
+                //TODO(jole) can not find request has such reason:
+                // 1. txn is expire.
+                // 2. txn is invalid.
+                None => bail!(
+                    "pending_txn_request must exist at stage:{:?}",
+                    channel.stage()
+                ),
+                Some(pending_txn) => {
+                    match pending_txn_to_onchain_txn(
+                        pending_txn,
+                        verified_participant_script_payload,
+                    )? {
+                        Some(raw_txn) => Some(self.inner.mock_signature(raw_txn)?),
+                        None => None,
+                    }
+                }
+            };
+            Ok(signed_txn)
+        })?;
+
+        // then, submit txn to chain
+        let gas = if let Some(signed_txn) = onchain_txn_to_submit {
+            let txn_with_proof = self.inner.submit_transaction(signed_txn).await?;
+            txn_with_proof.proof.transaction_info().gas_used()
+        } else {
+            0
+        };
+
+        // if ok, apply the channel txn to db
+        self.with_channel_mut(&participant, |channel| channel.apply())?;
+
+        info!("success apply channel request: {}", response.request_id());
+        Ok(gas)
+    }
+
     pub fn install_package(&self, package: ChannelScriptPackage) -> Result<()> {
         //TODO(jole) package should limit channel?
-        self.script_registry.install_package(package)?;
+        self.inner.script_registry.install_package(package)?;
         Ok(())
     }
 
@@ -735,37 +421,49 @@ where
         let txn = create_signed_payload_txn(
             self,
             payload,
-            self.account,
+            self.inner.account,
             self.sequence_number()?,
-            Self::MAX_GAS_AMOUNT_ONCHAIN,
-            Self::GAS_UNIT_PRICE,
-            Self::TXN_EXPIRATION.as_secs() as i64,
+            MAX_GAS_AMOUNT_ONCHAIN,
+            GAS_UNIT_PRICE,
+            TXN_EXPIRATION.as_secs() as i64,
         )?;
         //TODO need execute at local vm for check?
-        self.submit_transaction(txn).await
+        self.inner.submit_transaction(txn).await
     }
 
     pub fn get_script(&self, package_name: &str, script_name: &str) -> Option<ScriptCode> {
-        self.script_registry.get_script(package_name, script_name)
+        self.inner
+            .script_registry
+            .get_script(package_name, script_name)
     }
 
     pub fn get(&self, path: &DataPath) -> Result<Option<Vec<u8>>> {
         if path.is_channel_resource() {
             let participant = path.participant().expect("participant must exist");
             self.with_channel(&participant, |channel| {
-                Ok(channel.get(&AccessPath::new_for_data_path(self.account, path.clone())))
+                Ok(channel.get(&AccessPath::new_for_data_path(
+                    self.inner.account,
+                    path.clone(),
+                )))
             })
         } else {
-            let account_state = self.client.get_account_state(self.account, None)?;
+            let account_state = self
+                .inner
+                .client
+                .get_account_state(self.inner.account, None)?;
             Ok(account_state.get(&path.to_vec()))
         }
     }
 
     pub fn account_resource(&self) -> Result<AccountResource> {
-        // account_resource must exist.
-        //TODO handle unwrap
-        self.get(&DataPath::account_resource_data_path())
-            .and_then(|value| account_resource_ext::from_bytes(&value.unwrap()))
+        self.inner.account_resource()
+    }
+    pub fn sequence_number(&self) -> Result<u64> {
+        self.inner.sequence_number()
+    }
+    //TODO support more asset type
+    pub fn balance(&self) -> Result<u64> {
+        self.inner.balance()
     }
 
     pub fn channel_account_resource(
@@ -786,132 +484,11 @@ where
             .unwrap_or(0))
     }
 
-    pub fn sequence_number(&self) -> Result<u64> {
-        Ok(self.account_resource()?.sequence_number())
-    }
-
-    //TODO support more asset type
-    pub fn balance(&self) -> Result<u64> {
-        self.account_resource().map(|r| r.balance())
-    }
-
     pub fn channel_balance(&self, participant: AccountAddress) -> Result<u64> {
         Ok(self
             .channel_account_resource(participant)?
             .map(|account| account.balance())
             .unwrap_or(0))
-    }
-
-    fn channel_op_to_script(
-        &self,
-        channel_op: &ChannelOp,
-        args: Vec<TransactionArgument>,
-    ) -> Result<Script> {
-        let script_code = match channel_op {
-            ChannelOp::Open => self.script_registry.open_script(),
-            ChannelOp::Close => self.script_registry.close_script(),
-            ChannelOp::Execute {
-                package_name,
-                script_name,
-            } => self
-                .script_registry
-                .get_script(package_name, script_name)
-                .ok_or(format_err!(
-                    "Can not find script by package {} and script name {}",
-                    package_name,
-                    script_name
-                ))?,
-        };
-        let script = script_code.encode_script(args);
-        Ok(script)
-    }
-
-    fn build_raw_txn_from_channel_txn(
-        &self,
-        channel: &Channel,
-        channel_txn: &ChannelTransaction,
-        payload_key_and_signature: Option<(Ed25519PublicKey, Ed25519Signature)>,
-    ) -> Result<RawTransaction> {
-        let script =
-            self.channel_op_to_script(channel_txn.operator(), channel_txn.args().to_vec())?;
-        let write_set = channel.witness_data().unwrap_or_default();
-        let channel_script = ChannelScriptBody::new(
-            channel_txn.channel_sequence_number(),
-            write_set,
-            channel_txn.receiver(),
-            script,
-        );
-        let channel_txn_payload = match payload_key_and_signature {
-            Some((public_key, signature)) => {
-                // verify first
-                public_key.verify_signature(&channel_script.hash(), &signature)?;
-                ChannelTransactionPayload::new_with_script(channel_script, public_key, signature)
-            }
-            None => {
-                self.mock_payload_signature(ChannelTransactionPayloadBody::Script(channel_script))
-            }
-        };
-        Ok(RawTransaction::new_payload_txn(
-            channel_txn.sender(),
-            channel_txn.sequence_number(),
-            TransactionPayload::Channel(channel_txn_payload),
-            Self::MAX_GAS_AMOUNT_OFFCHAIN,
-            Self::GAS_UNIT_PRICE,
-            channel_txn.expiration_time(),
-        ))
-    }
-
-    fn txn_expiration() -> Duration {
-        std::time::Duration::new(
-            (Utc::now().timestamp() + Self::TXN_EXPIRATION.as_secs() as i64) as u64,
-            0,
-        )
-    }
-
-    /// Craft a mocked transaction request.
-    fn create_mocked_signed_script_txn(
-        &self,
-        channel: &Channel,
-        channel_txn: &ChannelTransaction,
-    ) -> Result<SignedTransaction> {
-        let txn = self.build_raw_txn_from_channel_txn(channel, channel_txn, None)?;
-        let signed_txn = self.mock_signature(txn)?;
-        Ok(signed_txn)
-    }
-
-    fn mock_signature(&self, txn: RawTransaction) -> Result<SignedTransaction> {
-        // execute txn on offchain vm, should mock sender and receiver signature with a local
-        // keypair. the vm will skip signature check on offchain vm.
-        let signed_txn = self.sign_txn(txn)?;
-        Ok(signed_txn)
-    }
-
-    fn mock_payload_signature(
-        &self,
-        payload_body: ChannelTransactionPayloadBody,
-    ) -> ChannelTransactionPayload {
-        payload_body.sign(&self.keypair.private_key, self.keypair.public_key.clone())
-    }
-
-    pub async fn submit_transaction(
-        &self,
-        signed_transaction: SignedTransaction,
-    ) -> Result<TransactionWithProof> {
-        let raw_txn_hash = signed_transaction.raw_txn().hash();
-        debug!("submit_transaction {}", raw_txn_hash);
-        let seq_number = signed_transaction.sequence_number();
-        let sender = &signed_transaction.sender();
-        let _resp = self.client.submit_signed_transaction(signed_transaction)?;
-        let watch_future = self.client.watch_transaction(sender, seq_number);
-        let (tx_proof, _account_proof) = watch_future.await?;
-        match tx_proof {
-            Some(proof) => Ok(proof),
-            None => Err(format_err!(
-                "proof not found by address {:?} and seq num {} .",
-                sender,
-                seq_number
-            )),
-        }
     }
 
     pub fn get_txn_by_channel_sequence_number(
@@ -946,7 +523,11 @@ where
         let mut channels = self.channels.write().unwrap();
         channels.insert(
             participant,
-            Channel::new(self.account, participant, self.get_channel_db(participant)),
+            Channel::new(
+                self.inner.account,
+                participant,
+                self.get_channel_db(participant),
+            ),
         );
     }
 
@@ -961,7 +542,6 @@ where
             .ok_or::<Error>(SgError::new_channel_not_exist_error(participant).into())?;
         action(channel)
     }
-
     fn with_channel_mut<T, F>(&self, participant: &AccountAddress, action: F) -> Result<T>
     where
         F: FnOnce(&mut Channel) -> Result<T>,
@@ -985,7 +565,7 @@ where
     C: ChainClient + Send + Sync + 'static,
 {
     fn sign_txn(&self, raw_txn: RawTransaction) -> Result<SignedTransaction> {
-        self.keypair.sign_txn(raw_txn)
+        self.inner.keypair.sign_txn(raw_txn)
     }
 }
 
@@ -994,6 +574,207 @@ where
     C: ChainClient + Send + Sync + 'static,
 {
     fn sign_bytes(&self, bytes: Vec<u8>) -> Result<Ed25519Signature> {
-        self.keypair.sign_bytes(bytes)
+        self.inner.keypair.sign_bytes(bytes)
+    }
+}
+
+pub struct WalletInner<C> {
+    account: AccountAddress,
+    keypair: Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
+    client: Arc<C>,
+    script_registry: Arc<PackageRegistry>,
+}
+
+// NOTICE: need to manually implement clone, due to https://github.com/rust-lang/rust/issues/26925
+impl<C> Clone for WalletInner<C> {
+    fn clone(&self) -> Self {
+        Self {
+            account: self.account.clone(),
+            keypair: Arc::clone(&self.keypair),
+            client: Arc::clone(&self.client),
+            script_registry: Arc::clone(&self.script_registry),
+        }
+    }
+}
+
+impl<C> WalletInner<C>
+where
+    C: ChainClient + Send + Sync + 'static,
+{
+    pub fn client(&self) -> &dyn ChainClient {
+        &*self.client
+    }
+
+    pub fn public_key(&self) -> &Ed25519PublicKey {
+        &self.keypair.public_key
+    }
+    pub fn sequence_number(&self) -> Result<u64> {
+        Ok(self.account_resource()?.sequence_number())
+    }
+
+    //TODO support more asset type
+    pub fn balance(&self) -> Result<u64> {
+        self.account_resource().map(|r| r.balance())
+    }
+
+    pub fn account_resource(&self) -> Result<AccountResource> {
+        // account_resource must exist.
+        //TODO handle unwrap
+        let account_state = self.client.get_account_state(self.account, None)?;
+        let account_resource_bytes = account_state
+            .get(&DataPath::account_resource_data_path().to_vec())
+            .unwrap();
+        account_resource_ext::from_bytes(&account_resource_bytes)
+    }
+
+    fn channel_op_to_script(
+        &self,
+        channel_op: &ChannelOp,
+        args: Vec<TransactionArgument>,
+    ) -> Result<Script> {
+        let script_code = match channel_op {
+            ChannelOp::Open => self.script_registry.open_script(),
+            ChannelOp::Close => self.script_registry.close_script(),
+            ChannelOp::Execute {
+                package_name,
+                script_name,
+            } => self
+                .script_registry
+                .get_script(package_name, script_name)
+                .ok_or(format_err!(
+                    "Can not find script by package {} and script name {}",
+                    package_name,
+                    script_name
+                ))?,
+        };
+        let script = script_code.encode_script(args);
+        Ok(script)
+    }
+
+    pub(crate) fn build_raw_txn_from_channel_txn(
+        &self,
+        channel_witness_data: Option<WriteSet>,
+        channel_txn: &ChannelTransaction,
+        payload_key_and_signature: Option<(Ed25519PublicKey, Ed25519Signature)>,
+    ) -> Result<RawTransaction> {
+        let script =
+            self.channel_op_to_script(channel_txn.operator(), channel_txn.args().to_vec())?;
+        let write_set = channel_witness_data.unwrap_or_default();
+        let channel_script = ChannelScriptBody::new(
+            channel_txn.channel_sequence_number(),
+            write_set,
+            channel_txn.receiver(),
+            script,
+        );
+        let channel_txn_payload = match payload_key_and_signature {
+            Some((public_key, signature)) => {
+                // verify first
+                public_key.verify_signature(&channel_script.hash(), &signature)?;
+                ChannelTransactionPayload::new_with_script(channel_script, public_key, signature)
+            }
+            None => {
+                self.mock_payload_signature(ChannelTransactionPayloadBody::Script(channel_script))
+            }
+        };
+        Ok(RawTransaction::new_payload_txn(
+            channel_txn.sender(),
+            channel_txn.sequence_number(),
+            TransactionPayload::Channel(channel_txn_payload),
+            MAX_GAS_AMOUNT_OFFCHAIN,
+            GAS_UNIT_PRICE,
+            channel_txn.expiration_time(),
+        ))
+    }
+    /// Craft a mocked transaction request.
+    pub(crate) fn create_mocked_signed_script_txn(
+        &self,
+        channel_witness_data: Option<WriteSet>,
+        channel_txn: &ChannelTransaction,
+    ) -> Result<SignedTransaction> {
+        let txn = self.build_raw_txn_from_channel_txn(channel_witness_data, channel_txn, None)?;
+        let signed_txn = self.mock_signature(txn)?;
+        Ok(signed_txn)
+    }
+
+    pub(crate) fn mock_signature(&self, txn: RawTransaction) -> Result<SignedTransaction> {
+        // execute txn on offchain vm, should mock sender and receiver signature with a local
+        // keypair. the vm will skip signature check on offchain vm.
+        let signed_txn = self.keypair.sign_txn(txn)?;
+        Ok(signed_txn)
+    }
+
+    fn mock_payload_signature(
+        &self,
+        payload_body: ChannelTransactionPayloadBody,
+    ) -> ChannelTransactionPayload {
+        payload_body.sign(&self.keypair.private_key, self.keypair.public_key.clone())
+    }
+
+    pub async fn submit_transaction(
+        &self,
+        signed_transaction: SignedTransaction,
+    ) -> Result<TransactionWithProof> {
+        let raw_txn_hash = signed_transaction.raw_txn().hash();
+        debug!("submit_transaction {}", raw_txn_hash);
+        let seq_number = signed_transaction.sequence_number();
+        let sender = &signed_transaction.sender();
+        let _resp = self.client.submit_signed_transaction(signed_transaction)?;
+        let watch_future = self.client.watch_transaction(sender, seq_number);
+        let (tx_proof, _account_proof) = watch_future.await?;
+        match tx_proof {
+            Some(proof) => Ok(proof),
+            None => Err(format_err!(
+                "proof not found by address {:?} and seq num {} .",
+                sender,
+                seq_number
+            )),
+        }
+    }
+
+    pub fn sign_message(&self, message: &HashValue) -> Ed25519Signature {
+        self.keypair.private_key.sign_message(message)
+    }
+}
+
+pub(crate) fn txn_expiration() -> Duration {
+    std::time::Duration::new(
+        (Utc::now().timestamp() + TXN_EXPIRATION.as_secs() as i64) as u64,
+        0,
+    )
+}
+
+pub(crate) fn execute_transaction(
+    state_view: &dyn StateView,
+    transaction: SignedTransaction,
+) -> Result<TransactionOutput> {
+    let tx_hash = transaction.raw_txn().hash();
+    let output = MoveVM::execute_block(
+        vec![Transaction::UserTransaction(transaction)],
+        &VM_CONFIG,
+        state_view,
+    )?
+    .pop()
+    .expect("at least return 1 output.");
+    debug!("execute txn:{} output: {}", tx_hash, output);
+    match output.status() {
+        TransactionStatus::Discard(vm_status) => {
+            bail!("transaction execute fail for: {:#?}", vm_status)
+        }
+        TransactionStatus::Keep(vm_status) => match vm_status.major_status {
+            StatusCode::EXECUTED => {
+                //continue
+            }
+            _ => bail!("transaction execute fail for: {:#?}", vm_status),
+        },
+    };
+    Ok(output)
+}
+
+pub(crate) fn get_channel_transaction_payload_body(
+    raw_txn: &RawTransaction,
+) -> Result<ChannelTransactionPayloadBody> {
+    match raw_txn.payload() {
+        TransactionPayload::Channel(payload) => Ok(payload.body.clone()),
+        _ => bail!("raw txn must a Channel Transaction"),
     }
 }


### PR DESCRIPTION
This PR:

- add two state of pending txn.

``` rust
pub enum PendingTransaction {
    WaitForReceiverSig { // sender wait for receiver's signatures
        request_id: HashValue,
        raw_tx: ChannelTransaction,
        output: TransactionOutput,
        sender_sigs: ChannelTransactionSigs,
    },
    WaitForApply { after check the signature, sender/receiver will apply this data.
        request_id: HashValue,
        raw_tx: ChannelTransaction,
        output: TransactionOutput,
        sender_sigs: ChannelTransactionSigs,
        receiver_sigs: ChannelTransactionSigs,
    },
}
```

- move most of functions on channel-request interaction into channel，which
 make channel a fat struct. After this, we can smoothly transform into actor model.
