### PR TITLE
wallet: impl channel event watcher

### DIFF
--- a/sgwallet/src/lib.rs
+++ b/sgwallet/src/lib.rs
@@ -7,7 +7,8 @@ pub mod scripts;
 pub mod tx_applier;
 pub mod wallet;
 pub use crate::channel_state_view::ChannelStateView;
-pub mod channel_event_watcher;
+mod channel_event_watcher;
+pub use channel_event_watcher::{get_channel_events, ChannelChangeEvent};
 #[macro_use]
 extern crate include_dir;
 

--- a/sgwallet/src/wallet.rs
+++ b/sgwallet/src/wallet.rs
@@ -152,6 +152,10 @@ impl Wallet {
         self.shared.client.as_ref()
     }
 
+    pub fn get_chain_client(&self) -> Arc<dyn ChainClient> {
+        self.shared.client.clone()
+    }
+
     /// TODO: use async version of cient
     pub fn account_resource(&self) -> Result<AccountResource> {
         // account_resource must exist.


### PR DESCRIPTION
This PR  implement a channel event stream with retry backoff.

Call `get_channel_events ` to get the stream, and use `Box::pin` on it and await on`try_next` to get events