### PR TITLE
feature: chain watcher

### DIFF
--- a/sgwallet/src/chain_watcher/mod.rs
+++ b/sgwallet/src/chain_watcher/mod.rs
@@ -1,0 +1,222 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::chain_watcher::txn_stream::TxnStream;
+use anyhow::bail;
+use anyhow::Result;
+use futures::channel::mpsc;
+use futures::channel::oneshot;
+use futures::{SinkExt, StreamExt};
+use libra_logger::prelude::*;
+use libra_types::transaction::Transaction;
+use sgchain::star_chain_client::ChainClient;
+use std::collections::HashMap;
+use std::sync::Arc;
+mod txn_stream;
+pub type Interest = Box<dyn Fn(&Transaction) -> bool + Send>;
+
+pub struct ChainWatcher {
+    chain_client: Arc<dyn ChainClient>,
+    interests: HashMap<Vec<u8>, Interest>,
+    down_streams: HashMap<Vec<u8>, mpsc::Sender<Transaction>>,
+    mailbox: mpsc::Receiver<InnerMsg>,
+    mailbox_sender: mpsc::Sender<InnerMsg>,
+}
+
+impl ChainWatcher {
+    pub fn new(chain_client: Arc<dyn ChainClient>) -> Self {
+        let (tx, rx) = mpsc::channel(1024);
+        Self {
+            chain_client,
+            interests: HashMap::new(),
+            down_streams: HashMap::new(),
+            mailbox: rx,
+            mailbox_sender: tx,
+        }
+    }
+
+    pub fn start(
+        self,
+        executor: tokio::runtime::Handle,
+        start_version: u64,
+        limit: u64,
+    ) -> Result<ChainWatcherHandle> {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let handle = ChainWatcherHandle {
+            mail_sender: self.mailbox_sender.clone(),
+            shutdown_tx,
+        };
+        let txn_stream = txn_stream::TxnStream::new_from_chain_client(
+            self.chain_client.clone(),
+            start_version,
+            limit,
+        );
+
+        executor.spawn(self.inner_start(txn_stream, shutdown_rx));
+        Ok(handle)
+    }
+}
+
+pub struct ChainWatcherHandle {
+    mail_sender: mpsc::Sender<InnerMsg>,
+    shutdown_tx: oneshot::Sender<()>,
+}
+
+impl ChainWatcherHandle {
+    pub async fn add_interest(
+        &self,
+        tag: Vec<u8>,
+        interest: Interest,
+    ) -> Result<mpsc::Receiver<Transaction>> {
+        let (tx, rx) = mpsc::channel(1024);
+        call(
+            self.mail_sender.clone(),
+            Request::AddInterest {
+                tag,
+                interest,
+                down_stream: tx,
+            },
+        )
+        .await?;
+
+        Ok(rx)
+    }
+    pub async fn remove_interest(&self, tag: Vec<u8>) -> Result<()> {
+        call(self.mail_sender.clone(), Request::RemoveInterest { tag }).await?;
+        Ok(())
+    }
+}
+
+enum Msg<ReqT, RespT> {
+    Call {
+        msg: ReqT,
+        tx: oneshot::Sender<RespT>,
+    },
+    Cast {
+        msg: ReqT,
+    },
+}
+
+enum Request {
+    AddInterest {
+        tag: Vec<u8>,
+        interest: Interest,
+        down_stream: mpsc::Sender<Transaction>,
+    },
+    RemoveInterest {
+        tag: Vec<u8>,
+    },
+}
+enum Response {
+    AddInterestResp,
+    RemoveInterestResp,
+}
+
+type InnerMsg = Msg<Request, Response>;
+
+impl ChainWatcher {
+    async fn inner_start(mut self, txn_stream: TxnStream, _shutdown_rx: oneshot::Receiver<()>) {
+        let mut fused_txn_stream = txn_stream.fuse();
+        loop {
+            futures::select! {
+                maybe_msg = self.mailbox.next() => {
+                   if let Some(msg) = maybe_msg {
+                       self.handle_msg(msg).await;
+                   }
+                }
+                maybe_txn = fused_txn_stream.next() => {
+                    if let Some(txn) = maybe_txn {
+                        self.handle_txn(txn).await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_txn(&mut self, txn: Result<Transaction>) {
+        match txn {
+            Err(e) => error!("fail to get txn from chain, e: {:#?}", e),
+            Ok(t) => {
+                let interested_stream = {
+                    let mut interested_stream = HashMap::new();
+                    for (tag, down_stream) in self.down_streams.iter() {
+                        match self.interests.get(tag) {
+                            None => error!("should contain interest"),
+                            Some(interest) => {
+                                if interest(&t) {
+                                    interested_stream.insert(tag.clone(), down_stream.clone());
+                                }
+                            }
+                        }
+                    }
+                    interested_stream
+                };
+
+                for (tag, mut s) in interested_stream.into_iter() {
+                    if let Err(_) = s.send(t.clone()).await {
+                        // drop disconnected interests
+                        self.remove_interest(&tag);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_msg(&mut self, msg: InnerMsg) {
+        match msg {
+            Msg::Call { msg, tx } => self.handle_call(msg, tx).await,
+            Msg::Cast { msg } => self.handle_cast(msg).await,
+        }
+    }
+    async fn handle_call(&mut self, msg: Request, responder: oneshot::Sender<Response>) {
+        let resp = match msg {
+            Request::AddInterest {
+                tag,
+                interest,
+                down_stream,
+            } => {
+                self.add_interest(tag, interest, down_stream);
+                Response::AddInterestResp
+            }
+            Request::RemoveInterest { tag } => {
+                self.remove_interest(&tag);
+                Response::RemoveInterestResp
+            }
+        };
+        respond_with(responder, resp);
+    }
+
+    async fn handle_cast(&mut self, _msg: Request) {
+        unimplemented!()
+    }
+
+    fn add_interest(&mut self, tag: Vec<u8>, interest: Interest, tx: mpsc::Sender<Transaction>) {
+        self.interests.insert(tag.clone(), interest);
+        self.down_streams.insert(tag.clone(), tx);
+    }
+
+    fn remove_interest(&mut self, tag: &Vec<u8>) {
+        self.interests.remove(tag);
+        self.down_streams.remove(tag);
+    }
+}
+
+async fn call<ReqT, RespT>(
+    mut mailbox_sender: mpsc::Sender<Msg<ReqT, RespT>>,
+    request: ReqT,
+) -> Result<RespT> {
+    let (tx, rx) = oneshot::channel();
+    if let Err(_e) = mailbox_sender.try_send(Msg::Call { msg: request, tx }) {
+        bail!("mailbox is full or close");
+    }
+    match rx.await {
+        Ok(result) => Ok(result),
+        Err(_) => bail!("sender dropped"),
+    }
+}
+
+fn respond_with<T>(responder: oneshot::Sender<T>, msg: T) {
+    if let Err(_t) = responder.send(msg) {
+        error!("fail to send back response, receiver is dropped",);
+    };
+}

--- a/sgwallet/src/chain_watcher/txn_stream.rs
+++ b/sgwallet/src/chain_watcher/txn_stream.rs
@@ -1,0 +1,61 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+use crate::data_stream::{DataQuery, DataStream};
+use anyhow::Result;
+use async_trait::async_trait;
+use libra_types::get_with_proof::RequestItem;
+use libra_types::transaction::{Transaction, Version};
+use sgchain::star_chain_client::ChainClient;
+use std::collections::BTreeMap;
+use std::convert::TryInto;
+use std::sync::Arc;
+
+pub type TxnStream = DataStream<Transaction>;
+
+impl TxnStream {
+    pub fn new_from_chain_client(
+        chain_client: Arc<dyn ChainClient>,
+        start_version: u64,
+        limit: u64,
+    ) -> Self {
+        DataStream::new(Box::new(TxnQuerier(chain_client)), start_version, limit)
+    }
+}
+
+pub(crate) fn build_request(
+    req: RequestItem,
+    ver: Option<Version>,
+) -> libra_types::proto::types::UpdateToLatestLedgerRequest {
+    libra_types::get_with_proof::UpdateToLatestLedgerRequest::new(ver.unwrap_or(0), vec![req])
+        .into()
+}
+
+struct TxnQuerier(Arc<dyn ChainClient>);
+#[async_trait]
+impl DataQuery for TxnQuerier {
+    type Item = Transaction;
+
+    async fn query(&self, version: u64, limit: u64) -> Result<BTreeMap<u64, Self::Item>> {
+        let ri = RequestItem::GetTransactions {
+            start_version: version,
+            limit,
+            fetch_events: false,
+        };
+        let mut resp = self.0.update_to_latest_ledger(&build_request(ri, None))?;
+        let resp: libra_types::get_with_proof::ResponseItem =
+            resp.response_items.remove(0).try_into()?;
+        let txns = resp.into_get_transactions_response()?;
+        // FIXME: check proof
+        match txns.first_transaction_version.as_ref() {
+            None => Ok(BTreeMap::new()),
+            Some(first_version) => {
+                let mut c = BTreeMap::default();
+
+                for (pos, t) in txns.transactions.into_iter().enumerate() {
+                    c.insert(*first_version + (pos as u64), t);
+                }
+                Ok(c)
+            }
+        }
+    }
+}

--- a/sgwallet/src/data_stream.rs
+++ b/sgwallet/src/data_stream.rs
@@ -1,0 +1,113 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use backoff::backoff::Backoff;
+use backoff::ExponentialBackoff;
+use futures::task::Context;
+use futures::task::Poll;
+use futures::{FutureExt, Stream};
+use futures_timer::Delay;
+use libra_logger::prelude::*;
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+
+#[async_trait]
+pub trait DataQuery: Send + Sync {
+    type Item;
+    async fn query(&self, version: u64, limit: u64) -> Result<BTreeMap<u64, Self::Item>>;
+}
+
+pub struct DataStream<T> {
+    start_number: u64,
+    limit: u64,
+    data_query: Box<dyn DataQuery<Item = T>>,
+    delay: Option<Delay>,
+    backoff: ExponentialBackoff,
+    cache: BTreeMap<u64, T>,
+}
+
+impl<T> DataStream<T> {
+    pub fn new(data_query: Box<dyn DataQuery<Item = T>>, start_version: u64, limit: u64) -> Self {
+        DataStream {
+            start_number: start_version,
+            limit,
+            data_query,
+            delay: None,
+            backoff: ExponentialBackoff::default(),
+            cache: BTreeMap::new(),
+        }
+    }
+}
+
+impl<T> DataStream<T> {
+    fn try_backoff(&mut self, cx: &mut Context<'_>) -> Result<()> {
+        match self.backoff.next_backoff() {
+            Some(next_backoff) => {
+                drop(self.delay.take());
+                debug!("next_backoff: {:?}", &next_backoff);
+                let mut delay = Delay::new(next_backoff);
+                match Pin::new(&mut delay).poll(cx) {
+                    Poll::Ready(_) => unreachable!(),
+                    Poll::Pending => {}
+                }
+                self.delay = Some(delay);
+                Ok(())
+            }
+            // FIXME: should err
+            None => bail!("backoff timout"),
+        }
+    }
+}
+
+impl<T: Unpin> Stream for DataStream<T> {
+    type Item = Result<T>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let s = self.get_mut();
+        match s.cache.remove(&s.start_number) {
+            Some(v) => {
+                s.start_number = s.start_number + 1;
+                Poll::Ready(Some(Ok(v)))
+            }
+            None => {
+                if let Some(delay) = s.delay.as_mut() {
+                    match Pin::new(delay).poll(cx) {
+                        Poll::Ready(_) => {}
+                        Poll::Pending => return Poll::Pending,
+                    }
+                }
+                debug_assert!(s.cache.is_empty());
+
+                let event_query = s.data_query.query(s.start_number, s.limit).poll_unpin(cx);
+
+                match event_query {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(Ok(data)) => {
+                        s.backoff.reset();
+                        if !data.is_empty() {
+                            s.cache = data;
+                            match s.cache.remove(&s.start_number) {
+                                Some(v) => {
+                                    s.start_number = s.start_number + 1;
+                                    Poll::Ready(Some(Ok(v)))
+                                }
+                                None => unreachable!(),
+                            }
+                        } else {
+                            match s.try_backoff(cx) {
+                                Err(e) => Poll::Ready(Some(Err(e))),
+                                Ok(_) => Poll::Pending,
+                            }
+                        }
+                    }
+                    Poll::Ready(Err(_e)) => match s.try_backoff(cx) {
+                        Err(e) => Poll::Ready(Some(Err(e))),
+                        Ok(_) => Poll::Pending,
+                    },
+                }
+            }
+        }
+    }
+}

--- a/sgwallet/src/lib.rs
+++ b/sgwallet/src/lib.rs
@@ -7,7 +7,7 @@ pub mod scripts;
 pub mod tx_applier;
 pub mod wallet;
 pub use crate::channel_state_view::ChannelStateView;
-mod chain_watcher;
+pub mod chain_watcher;
 mod channel_event_watcher;
 mod data_stream;
 pub mod utils;

--- a/sgwallet/src/lib.rs
+++ b/sgwallet/src/lib.rs
@@ -7,7 +7,9 @@ pub mod scripts;
 pub mod tx_applier;
 pub mod wallet;
 pub use crate::channel_state_view::ChannelStateView;
+mod chain_watcher;
 mod channel_event_watcher;
+mod data_stream;
 pub mod utils;
 pub use channel_event_watcher::{get_channel_events, ChannelChangeEvent};
 #[macro_use]

--- a/sgwallet/src/utils/actor.rs
+++ b/sgwallet/src/utils/actor.rs
@@ -1,0 +1,51 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use futures::channel::{mpsc, oneshot};
+use libra_logger::prelude::*;
+
+#[derive(Debug)]
+pub enum Msg<ReqT, RespT> {
+    Call {
+        msg: ReqT,
+        tx: oneshot::Sender<RespT>,
+    },
+    Cast {
+        msg: ReqT,
+    },
+}
+
+pub async fn call<ReqT, RespT>(
+    mut mailbox_sender: mpsc::Sender<Msg<ReqT, RespT>>,
+    request: ReqT,
+) -> Result<RespT> {
+    let (tx, rx) = oneshot::channel();
+    if let Err(_e) = mailbox_sender.try_send(Msg::Call { msg: request, tx }) {
+        bail!("mailbox is full or close");
+    }
+    match rx.await {
+        Ok(result) => Ok(result),
+        Err(_) => bail!("sender dropped"),
+    }
+}
+
+pub fn cast<ReqT, RespT>(
+    mut mailbox_sender: mpsc::Sender<Msg<ReqT, RespT>>,
+    request: ReqT,
+) -> Result<()> {
+    if let Err(e) = mailbox_sender.try_send(Msg::Cast { msg: request }) {
+        if e.is_full() {
+            bail!("mailbox is full");
+        } else {
+            error!("mailbox is closed");
+        }
+    }
+    Ok(())
+}
+
+pub fn respond_with<T>(responder: oneshot::Sender<T>, msg: T) {
+    if let Err(_t) = responder.send(msg) {
+        error!("fail to send back response, receiver is dropped",);
+    };
+}

--- a/sgwallet/src/utils/mod.rs
+++ b/sgwallet/src/utils/mod.rs
@@ -6,6 +6,8 @@ use libra_types::account_address::AccountAddress;
 use libra_types::transaction::TransactionArgument;
 use sgtypes::channel_transaction::ChannelOp;
 use sgtypes::htlc::HtlcPayment;
+mod actor;
+pub use actor::*;
 
 /// check if the `op` is a htlc transfer
 pub fn is_htlc_transfer(op: &ChannelOp) -> bool {

--- a/sgwallet/tests/test_chain_watcher.rs
+++ b/sgwallet/tests/test_chain_watcher.rs
@@ -1,0 +1,53 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Error;
+use futures::StreamExt;
+use libra_logger::{debug, error};
+use libra_types::account_address::AccountAddress;
+use libra_types::transaction::Transaction;
+use sgchain::star_chain_client::{ChainClient, MockChainClient};
+use sgwallet::chain_watcher::*;
+use std::sync::Arc;
+
+pub fn run_with_mock_client<F, T>(mut f: F) -> T
+where
+    F: FnMut(Arc<dyn ChainClient>) -> T,
+{
+    libra_logger::try_init_for_testing();
+    let (mock_chain_service, _handle) = MockChainClient::new();
+    //    std::thread::sleep(Duration::from_millis(1500));
+    let chain_client = Arc::new(mock_chain_service);
+    f(chain_client.clone())
+}
+
+#[test]
+pub fn test_chain_watcher() {
+    run_with_mock_client(|chain_client| run_test_chain_watcher(chain_client));
+}
+
+fn run_test_chain_watcher(chain_client: Arc<dyn ChainClient>) {
+    let chain_watcher = ChainWatcher::new(chain_client.clone());
+    let mut rt = tokio::runtime::Runtime::new().expect("create tokio runtime should ok");
+    let rt_handle = rt.handle().clone();
+    let chain_watcher_handle = chain_watcher
+        .start(rt_handle, 0, 100)
+        .expect("spawn chain watcher should ok");
+
+    let res = rt.block_on(async move {
+        let mut receiver = chain_watcher_handle
+            .add_interest("test".to_string().into_bytes(), Box::new(|_txn| true))
+            .await?;
+        chain_client.faucet(AccountAddress::random(), 10000).await?;
+        let txn: Option<Transaction> = receiver.next().await;
+        assert!(txn.is_some());
+        let txn = txn.unwrap();
+        let signed_txn = txn.as_signed_user_txn()?;
+        debug!("watched txn: {:#?}", signed_txn);
+        Ok::<_, Error>(())
+    });
+    if let Err(e) = res {
+        error!("test_chain_watcher fail, error: {:#?}", e);
+        assert!(false);
+    }
+}


### PR DESCRIPTION
This PR add a simple stream-based chain watcher.
User can add custom interest on chain txns, and get a mpsc receiver to receive the txns.

Fow now, the watch is just a loop of blocking get remote txn based on txn version. It should be refactor into async style.