### PR TITLE
fix(chain_client): use block_in_place to reslove sync call.

### DIFF
--- a/sgwallet/src/chain_watcher/txn_stream.rs
+++ b/sgwallet/src/chain_watcher/txn_stream.rs
@@ -41,7 +41,12 @@ impl DataQuery for TxnQuerier {
             limit,
             fetch_events: false,
         };
-        let mut resp = self.0.update_to_latest_ledger(&build_request(ri, None))?;
+        let client = self.0.clone();
+
+        let mut resp = tokio::task::block_in_place(move || {
+            client.update_to_latest_ledger(&build_request(ri, None))
+        })?;
+
         let resp: libra_types::get_with_proof::ResponseItem =
             resp.response_items.remove(0).try_into()?;
         let txns = resp.into_get_transactions_response()?;

--- a/sgwallet/src/channel_event_watcher.rs
+++ b/sgwallet/src/channel_event_watcher.rs
@@ -121,9 +121,10 @@ impl ChainClientEventQuerier {
         version: Option<u64>,
     ) -> Result<Option<BTreeMap<Vec<u8>, Vec<u8>>>> {
         let ri = RequestItem::GetAccountState { address: addr };
-        let mut resp = self
-            .0
-            .update_to_latest_ledger(&build_request(ri, version))?;
+        let client = self.0.clone();
+        let mut resp = tokio::task::block_in_place(move || {
+            client.update_to_latest_ledger(&build_request(ri, version))
+        })?;
         let resp: libra_types::get_with_proof::ResponseItem =
             resp.response_items.remove(0).try_into()?;
         let s = resp.into_get_account_state_response()?;
@@ -145,7 +146,10 @@ impl DataQuery for ChainClientEventQuerier {
             ascending: true,
             limit,
         };
-        let mut resp = self.0.update_to_latest_ledger(&build_request(ri, None))?;
+        let client = self.0.clone();
+        let mut resp = tokio::task::block_in_place(move || {
+            client.update_to_latest_ledger(&build_request(ri, None))
+        })?;
 
         let resp: libra_types::get_with_proof::ResponseItem =
             resp.response_items.remove(0).try_into()?;


### PR DESCRIPTION
I also tried task::spawn_blocking, but it's not working normally.
Need to dive into this to get good understanding.