### PR TITLE
wallet: remove handwriting actor handle loop, use coerce instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 [[package]]
 name = "coerce-rt"
 version = "0.1.2-pre"
-source = "git+https://github.com/starcoinorg/Coerce-rs.git?branch=stargate#11d840966648d3b0080de2b99b005d9079ccb825"
+source = "git+https://github.com/starcoinorg/Coerce-rs.git?branch=stargate#807a9798538f9c79f8c5a2dbc1c97c4243941c85"
 dependencies = [
  "async-trait 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/node/node_internal/src/node.rs
+++ b/node/node_internal/src/node.rs
@@ -24,7 +24,7 @@ use sgtypes::{
     message::*,
     system_event::Event,
 };
-use sgwallet::{utils::*, wallet::Wallet};
+use sgwallet::{utils::*, wallet::WalletHandle};
 
 use crate::message_processor::{MessageFuture, MessageProcessor};
 
@@ -56,12 +56,12 @@ pub struct Node {
     network_service_close_tx: Option<oneshot::Sender<()>>,
     router_message_receiver:
         Option<futures::channel::mpsc::UnboundedReceiver<(AccountAddress, RouterNetworkMessage)>>,
-    wallet: Arc<Wallet>,
+    wallet: Arc<WalletHandle>,
     invoice_mgr: InvoiceManager,
 }
 
 struct NodeInner {
-    wallet: Arc<Wallet>,
+    wallet: Arc<WalletHandle>,
     executor: Handle,
     sender: UnboundedSender<NetworkMessage>,
     message_processor: MessageProcessor<u64>,
@@ -77,7 +77,7 @@ struct NodeInner {
 impl Node {
     pub fn new(
         executor: Handle,
-        wallet: Arc<Wallet>,
+        wallet: Arc<WalletHandle>,
         network_service: NetworkService,
         sender: UnboundedSender<NetworkMessage>,
         receiver: UnboundedReceiver<NetworkMessage>,
@@ -701,7 +701,7 @@ impl Node {
 }
 
 impl Node {
-    pub fn wallet(&self) -> Arc<Wallet> {
+    pub fn wallet(&self) -> Arc<WalletHandle> {
         self.wallet.clone()
     }
 }

--- a/node/node_internal/src/node.rs
+++ b/node/node_internal/src/node.rs
@@ -694,6 +694,10 @@ impl Node {
                     node_inner.shutdown().await;
                     break;
                 }
+                complete => {
+                    warn!("all stream are complete");
+                    break;
+                }
             }
         }
         info!("shutdown command listener");

--- a/node/node_internal/src/node_test.rs
+++ b/node/node_internal/src/node_test.rs
@@ -38,7 +38,7 @@ fn node_test_all() -> Result<()> {
     );
 
     let (mut node1, addr1) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config1,
         client.clone(),
@@ -55,7 +55,7 @@ fn node_test_all() -> Result<()> {
     );
 
     let (mut node2, addr2) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config2,
         client.clone(),
@@ -68,7 +68,7 @@ fn node_test_all() -> Result<()> {
         vec![seed.clone()],
     );
     let (mut node3, addr3) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config3,
         client.clone(),
@@ -282,7 +282,7 @@ fn node_test_four_hop() -> Result<()> {
     let client = Arc::new(mock_chain_service);
     let network_config1 = create_node_network_config("/ip4/127.0.0.1/tcp/5000".to_string(), vec![]);
     let (mut node1, addr1) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config1,
         client.clone(),
@@ -299,7 +299,7 @@ fn node_test_four_hop() -> Result<()> {
     );
 
     let (mut node2, addr2) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config2,
         client.clone(),
@@ -312,7 +312,7 @@ fn node_test_four_hop() -> Result<()> {
         vec![seed.clone()],
     );
     let (mut node3, addr3) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config3,
         client.clone(),
@@ -325,7 +325,7 @@ fn node_test_four_hop() -> Result<()> {
         vec![seed.clone()],
     );
     let (mut node4, addr4) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config4,
         client.clone(),
@@ -531,7 +531,7 @@ fn node_test_approve() -> Result<()> {
     );
 
     let (mut node1, addr1) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config1,
         client.clone(),
@@ -548,7 +548,7 @@ fn node_test_approve() -> Result<()> {
         vec![seed],
     );
     let (mut node2, addr2) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config2,
         client.clone(),
@@ -625,7 +625,7 @@ fn node_test_reject() -> Result<()> {
     );
 
     let (mut node1, addr1) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config1,
         client.clone(),
@@ -642,7 +642,7 @@ fn node_test_reject() -> Result<()> {
         vec![seed],
     );
     let (mut node2, addr2) = gen_node(
-        &mut rt,
+        rt.block_on(setup_wallet(client.clone(), 10_000_000))?,
         executor.clone(),
         &network_config2,
         client.clone(),
@@ -702,6 +702,7 @@ async fn _delay(duration: Duration) {
 }
 
 /// wait until the channel seq number between node1 and node2 is what we wanted
+#[allow(dead_code)]
 async fn wait_channel_sequence_number(
     node1: Arc<Node>,
     node2: Arc<Node>,

--- a/node/node_internal/src/test_helper.rs
+++ b/node/node_internal/src/test_helper.rs
@@ -1,57 +1,58 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+#![allow(dead_code)]
 
 use network::build_network_service;
 use rand::prelude::*;
 
-use crate::get_unix_ts;
 use crate::node::Node;
-use anyhow::Error;
+use anyhow::Result;
+use libra_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use libra_crypto::{test_utils::KeyPair, Uniform};
 use libra_tools::tempdir::TempPath;
 use libra_types::account_address::AccountAddress;
 use router::TableRouter;
 use sg_config::config::NetworkConfig;
-use sgchain::star_chain_client::{faucet_sync, MockChainClient};
+use sgchain::star_chain_client::{ChainClient, MockChainClient};
 use sgwallet::wallet::*;
 use stats::Stats;
 use std::{sync::Arc, thread, time::Duration};
-use tokio::runtime::{Handle, Runtime};
+use tokio::runtime::Handle;
+
+pub async fn setup_wallet(client: Arc<dyn ChainClient>, init_balance: u64) -> Result<WalletHandle> {
+    let mut seed_rng = rand::rngs::OsRng::new().expect("can't access OsRng");
+    let seed_buf: [u8; 32] = seed_rng.gen();
+    let mut rng0: StdRng = SeedableRng::from_seed(seed_buf);
+    let account_keypair: Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>> =
+        Arc::new(KeyPair::generate_for_testing(&mut rng0));
+    let account = AccountAddress::from_public_key(&account_keypair.public_key);
+
+    client.faucet(account, init_balance).await?;
+    // enable channel for wallet
+    let wallet =
+        Wallet::new_with_client(account, account_keypair, client.clone(), TempPath::new())?;
+    let handle = wallet.start().await?;
+    let gas_used = handle.enable_channel().await?;
+    handle.get_chain_client().faucet(account, gas_used).await?;
+
+    let wallet_balance = handle.balance()?;
+    assert_eq!(
+        init_balance, wallet_balance,
+        "not equal, balance: {:?}",
+        wallet_balance
+    );
+    Ok(handle)
+}
 
 pub fn gen_node(
-    rt: &mut Runtime,
+    wallet: WalletHandle,
     executor: Handle,
     config: &NetworkConfig,
     client: Arc<MockChainClient>,
     auto_approve: bool,
 ) -> (Node, AccountAddress) {
-    let amount: u64 = 10_000_000;
-    let mut rng: StdRng = SeedableRng::seed_from_u64(get_unix_ts()); //SeedableRng::from_seed([0; 32]);
-    let keypair = Arc::new(KeyPair::generate_for_testing(&mut rng));
-    let account_address = AccountAddress::from_public_key(&keypair.public_key);
-    faucet_sync(client.as_ref().clone(), account_address, amount).unwrap();
-    let store_path = TempPath::new();
-
-    let mut wallet = Wallet::new_with_client(
-        account_address,
-        keypair.clone(),
-        client.clone(),
-        store_path.path(),
-    )
-    .unwrap();
-    wallet.start(&executor).unwrap();
-
-    let f = async {
-        let enabled: bool = wallet.is_channel_feature_enabled().await?;
-        if !enabled {
-            wallet.enable_channel().await?;
-        }
-        Ok::<_, Error>(())
-    };
-    rt.block_on(f).unwrap();
-
     let wallet = Arc::new(wallet);
-
+    let account_address = wallet.account();
     let (rtx1, rrx1) = futures::channel::mpsc::unbounded();
     let (rtx2, rrx2) = futures::channel::mpsc::unbounded();
 
@@ -66,7 +67,7 @@ pub fn gen_node(
     );
     router.start().unwrap();
 
-    let (network, tx, rx, close_tx) = build_network_service(config, keypair.clone());
+    let (network, tx, rx, close_tx) = build_network_service(config, wallet.keypair());
     let _identify = network.identify();
 
     thread::sleep(Duration::from_millis(1000));

--- a/node/node_internal/src/test_helper.rs
+++ b/node/node_internal/src/test_helper.rs
@@ -82,7 +82,7 @@ pub fn gen_node(
             rrx1,
             close_tx,
             auto_approve,
-            5000,
+            10000,
             Box::new(router),
         ),
         account_address,

--- a/router/ant/src/lib.rs
+++ b/router/ant/src/lib.rs
@@ -4,9 +4,8 @@ mod seed_generator;
 
 use anyhow::*;
 use tokio::runtime::Handle;
-use tokio::runtime::Runtime;
 
-use sgwallet::wallet::Wallet;
+use sgwallet::wallet::{Wallet, WalletHandle};
 use std::sync::Arc;
 
 use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -67,7 +66,7 @@ impl MixRouter {
         executor: Handle,
         network_sender: UnboundedSender<(AccountAddress, RouterNetworkMessage)>,
         network_receiver: UnboundedReceiver<(AccountAddress, RouterNetworkMessage)>,
-        wallet: Arc<Wallet>,
+        wallet: Arc<WalletHandle>,
         stats_mgr: Arc<Stats>,
         default_future_timeout: u64,
     ) -> Self {
@@ -241,7 +240,7 @@ pub struct AntRouter {
 
 struct AntRouterInner {
     network_sender: UnboundedSender<(AccountAddress, RouterNetworkMessage)>,
-    wallet: Arc<Wallet>,
+    wallet: Arc<WalletHandle>,
     seed_manager: SeedManager,
     message_processor: MessageProcessor<RouterNetworkMessage>,
     default_future_timeout: AtomicU64,
@@ -263,7 +262,7 @@ impl AntRouter {
         executor: Handle,
         network_sender: UnboundedSender<(AccountAddress, RouterNetworkMessage)>,
         network_receiver: UnboundedReceiver<(AccountAddress, RouterNetworkMessage)>,
-        wallet: Arc<Wallet>,
+        wallet: Arc<WalletHandle>,
         default_future_timeout: u64,
         stats_mgr: Arc<Stats>,
     ) -> Self {
@@ -681,11 +680,11 @@ fn respond_with<T>(responder: futures::channel::oneshot::Sender<T>, msg: T) {
     };
 }
 
-fn _gen_wallet(
-    executor: Handle,
+#[allow(dead_code)]
+async fn _gen_wallet(
     client: Arc<MockChainClient>,
 ) -> Result<(
-    Arc<Wallet>,
+    Arc<WalletHandle>,
     AccountAddress,
     Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
 )> {
@@ -693,24 +692,16 @@ fn _gen_wallet(
     let mut rng: StdRng = SeedableRng::seed_from_u64(_get_unix_ts()); //SeedableRng::from_seed([0; 32]);
     let keypair = Arc::new(KeyPair::generate_for_testing(&mut rng));
     let account_address = AccountAddress::from_public_key(&keypair.public_key);
-    let mut rt = Runtime::new().expect("faucet runtime err.");
-    let f = async {
-        faucet_async_2(client.as_ref().clone(), account_address, amount)
-            .await
-            .unwrap();
-    };
-    rt.block_on(f);
+
+    faucet_async_2(client.as_ref().clone(), account_address, amount)
+        .await
+        .unwrap();
     let store_path = TempPath::new();
-    let mut wallet =
-        Wallet::new_with_client(account_address, keypair.clone(), client, store_path.path())
-            .unwrap();
-    wallet.start(&executor).unwrap();
+    let wallet =
+        Wallet::new_with_client(account_address, keypair.clone(), client, store_path.path())?;
 
-    let f = async {
-        wallet.enable_channel().await.unwrap();
-    };
-    rt.block_on(f);
-
+    let wallet = wallet.start().await?;
+    wallet.enable_channel().await?;
     Ok((Arc::new(wallet), account_address, keypair))
 }
 
@@ -719,8 +710,8 @@ async fn _delay(duration: Duration) {
 }
 
 async fn _open_channel(
-    sender_wallet: Arc<Wallet>,
-    receiver_wallet: Arc<Wallet>,
+    sender_wallet: Arc<WalletHandle>,
+    receiver_wallet: Arc<WalletHandle>,
     sender_amount: u64,
     receiver_amount: u64,
 ) -> Result<u64> {
@@ -773,6 +764,7 @@ fn mix_router_test() {
     use libra_logger::prelude::*;
     use sgchain::star_chain_client::MockChainClient;
     use std::sync::Arc;
+    use tokio::runtime::Runtime;
 
     libra_logger::init_for_e2e_testing();
     let mut rt = Runtime::new().unwrap();
@@ -781,9 +773,9 @@ fn mix_router_test() {
     let (mock_chain_service, _handle) = MockChainClient::new();
     let client = Arc::new(mock_chain_service);
 
-    let (wallet1, addr1, keypair1) = _gen_wallet(executor.clone(), client.clone()).unwrap();
-    let (wallet2, addr2, keypair2) = _gen_wallet(executor.clone(), client.clone()).unwrap();
-    let (wallet3, addr3, keypair3) = _gen_wallet(executor.clone(), client.clone()).unwrap();
+    let (wallet1, addr1, keypair1) = rt.block_on(_gen_wallet(client.clone())).unwrap();
+    let (wallet2, addr2, keypair2) = rt.block_on(_gen_wallet(client.clone())).unwrap();
+    let (wallet3, addr3, keypair3) = rt.block_on(_gen_wallet(client.clone())).unwrap();
 
     let _wallet1 = wallet1.clone();
     let _wallet2 = wallet2.clone();
@@ -918,6 +910,7 @@ fn ant_router_test() {
     use libra_logger::prelude::*;
     use sgchain::star_chain_client::MockChainClient;
     use std::sync::Arc;
+    use tokio::runtime::Runtime;
 
     libra_logger::init_for_e2e_testing();
     let mut rt = Runtime::new().unwrap();
@@ -926,11 +919,11 @@ fn ant_router_test() {
     let (mock_chain_service, _handle) = MockChainClient::new();
     let client = Arc::new(mock_chain_service);
 
-    let (wallet1, addr1, keypair1) = _gen_wallet(executor.clone(), client.clone()).unwrap();
-    let (wallet2, addr2, keypair2) = _gen_wallet(executor.clone(), client.clone()).unwrap();
-    let (wallet3, _addr3, keypair3) = _gen_wallet(executor.clone(), client.clone()).unwrap();
-    let (wallet4, addr4, keypair4) = _gen_wallet(executor.clone(), client.clone()).unwrap();
-    let (wallet5, addr5, keypair5) = _gen_wallet(executor.clone(), client.clone()).unwrap();
+    let (wallet1, addr1, keypair1) = rt.block_on(_gen_wallet(client.clone())).unwrap();
+    let (wallet2, addr2, keypair2) = rt.block_on(_gen_wallet(client.clone())).unwrap();
+    let (wallet3, _addr3, keypair3) = rt.block_on(_gen_wallet(client.clone())).unwrap();
+    let (wallet4, addr4, keypair4) = rt.block_on(_gen_wallet(client.clone())).unwrap();
+    let (wallet5, addr5, keypair5) = rt.block_on(_gen_wallet(client.clone())).unwrap();
 
     let _wallet1 = wallet1.clone();
     let _wallet2 = wallet2.clone();

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -25,7 +25,7 @@ use sgchain::star_chain_client::ChainClient;
 use sgchain::star_chain_client::{faucet_async_2, MockChainClient};
 use sgtypes::message::{BalanceQueryRequest, BalanceQueryResponse, RouterNetworkMessage};
 use sgtypes::system_event::Event;
-use sgwallet::wallet::Wallet;
+use sgwallet::wallet::{Wallet, WalletHandle};
 use sgwallet::{get_channel_events, ChannelChangeEvent};
 use stats::{DirectedChannel, PaymentInfo, Stats};
 use std::collections::{HashMap, HashSet};
@@ -34,7 +34,6 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::runtime::Handle;
-use tokio::runtime::Runtime;
 
 #[async_trait]
 pub trait Router: Send + Sync {
@@ -64,7 +63,7 @@ pub struct TableRouter {
 struct RouterInner {
     graph_store: GraphStore,
     network_sender: UnboundedSender<(AccountAddress, RouterNetworkMessage)>,
-    wallet: Arc<Wallet>,
+    wallet: Arc<WalletHandle>,
     message_processor: MessageProcessor<RouterNetworkMessage>,
     stats_mgr: Arc<Stats>,
 }
@@ -81,7 +80,7 @@ impl TableRouter {
     pub fn new(
         chain_client: Arc<dyn ChainClient>,
         executor: Handle,
-        wallet: Arc<Wallet>,
+        wallet: Arc<WalletHandle>,
         network_sender: UnboundedSender<(AccountAddress, RouterNetworkMessage)>,
         network_receiver: UnboundedReceiver<(AccountAddress, RouterNetworkMessage)>,
         stats_mgr: Arc<Stats>,
@@ -479,6 +478,7 @@ fn router_test() {
     use libra_logger::prelude::*;
     use sgchain::star_chain_client::MockChainClient;
     use std::sync::Arc;
+    use tokio::runtime::Runtime;
 
     libra_logger::init_for_e2e_testing();
     let mut rt = Runtime::new().unwrap();
@@ -487,11 +487,11 @@ fn router_test() {
     let (mock_chain_service, _handle) = MockChainClient::new();
     let client = Arc::new(mock_chain_service);
 
-    let (wallet1, addr1, keypair1) = _gen_wallet(executor.clone(), client.clone()).unwrap();
-    let (wallet2, addr2, keypair2) = _gen_wallet(executor.clone(), client.clone()).unwrap();
-    let (wallet3, _addr3, keypair3) = _gen_wallet(executor.clone(), client.clone()).unwrap();
-    let (wallet4, addr4, keypair4) = _gen_wallet(executor.clone(), client.clone()).unwrap();
-    let (wallet5, addr5, keypair5) = _gen_wallet(executor.clone(), client.clone()).unwrap();
+    let (wallet1, addr1, keypair1) = rt.block_on(_gen_wallet(client.clone())).unwrap();
+    let (wallet2, addr2, keypair2) = rt.block_on(_gen_wallet(client.clone())).unwrap();
+    let (wallet3, _addr3, keypair3) = rt.block_on(_gen_wallet(client.clone())).unwrap();
+    let (wallet4, addr4, keypair4) = rt.block_on(_gen_wallet(client.clone())).unwrap();
+    let (wallet5, addr5, keypair5) = rt.block_on(_gen_wallet(client.clone())).unwrap();
 
     let _wallet1 = wallet1.clone();
     let _wallet2 = wallet2.clone();
@@ -664,11 +664,11 @@ fn router_test() {
     debug!("here");
 }
 
-fn _gen_wallet(
-    executor: Handle,
+#[allow(dead_code)]
+async fn _gen_wallet(
     client: Arc<MockChainClient>,
 ) -> Result<(
-    Arc<Wallet>,
+    Arc<WalletHandle>,
     AccountAddress,
     Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
 )> {
@@ -676,24 +676,16 @@ fn _gen_wallet(
     let mut rng: StdRng = SeedableRng::seed_from_u64(_get_unix_ts()); //SeedableRng::from_seed([0; 32]);
     let keypair = Arc::new(KeyPair::generate_for_testing(&mut rng));
     let account_address = AccountAddress::from_public_key(&keypair.public_key);
-    let mut rt = Runtime::new().expect("faucet runtime err.");
-    let f = async {
-        faucet_async_2(client.as_ref().clone(), account_address, amount)
-            .await
-            .unwrap();
-    };
-    rt.block_on(f);
+
+    faucet_async_2(client.as_ref().clone(), account_address, amount)
+        .await
+        .unwrap();
     let store_path = TempPath::new();
-    let mut wallet =
+    let wallet =
         Wallet::new_with_client(account_address, keypair.clone(), client, store_path.path())
             .unwrap();
-    wallet.start(&executor).unwrap();
-
-    let f = async {
-        wallet.enable_channel().await.unwrap();
-    };
-    rt.block_on(f);
-
+    let wallet = wallet.start().await.unwrap();
+    wallet.enable_channel().await.unwrap();
     Ok((Arc::new(wallet), account_address, keypair))
 }
 
@@ -702,8 +694,8 @@ async fn _delay(duration: Duration) {
 }
 
 async fn _open_channel(
-    sender_wallet: Arc<Wallet>,
-    receiver_wallet: Arc<Wallet>,
+    sender_wallet: Arc<WalletHandle>,
+    receiver_wallet: Arc<WalletHandle>,
     sender_amount: u64,
     receiver_amount: u64,
 ) -> Result<u64> {

--- a/sgtypes/src/channel_transaction.rs
+++ b/sgtypes/src/channel_transaction.rs
@@ -13,7 +13,7 @@ use libra_crypto::{
 use libra_crypto_derive::CryptoHasher;
 use libra_prost_ext::MessageExt;
 use libra_types::account_address::AccountAddress;
-use libra_types::transaction::{ScriptAction, TransactionArgument, Version};
+use libra_types::transaction::{TransactionArgument, Version};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;

--- a/sgwallet/src/channel/channel.rs
+++ b/sgwallet/src/channel/channel.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+use crate::wallet::ChannelNotifyEvent;
 use crate::{
     channel::{
         access_local, channel_event_stream::ChannelEventStream, AccessingResource,
@@ -22,7 +23,7 @@ use coerce_rt::actor::{
     message::{Handler, Message},
     Actor, ActorRef,
 };
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 use libra_crypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
     hash::CryptoHash,
@@ -127,8 +128,10 @@ impl Actor for Channel {
     async fn stopped(&mut self, _ctx: &mut ActorHandlerContext) {
         if let Err(e) = self
             .channel_event_sender
-            .send(ChannelEvent::Stopped {
-                channel_address: self.channel_address,
+            .notify(ChannelNotifyEvent {
+                channel_event: ChannelEvent::Stopped {
+                    channel_address: self.channel_address,
+                },
             })
             .await
         {

--- a/sgwallet/src/utils/coerce_derive.rs
+++ b/sgwallet/src/utils/coerce_derive.rs
@@ -1,0 +1,2 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0

--- a/sgwallet/src/utils/mod.rs
+++ b/sgwallet/src/utils/mod.rs
@@ -5,6 +5,7 @@ use libra_crypto::HashValue;
 use libra_types::{account_address::AccountAddress, transaction::TransactionArgument};
 use sgtypes::{channel_transaction::ChannelOp, htlc::HtlcPayment};
 pub(crate) mod actor_timer;
+pub mod coerce_derive;
 pub(crate) mod contract;
 
 /// check if the `op` is a htlc transfer

--- a/sgwallet/src/wallet.rs
+++ b/sgwallet/src/wallet.rs
@@ -116,7 +116,9 @@ impl WalletHandle {
     pub fn account(&self) -> AccountAddress {
         self.shared.account
     }
-
+    pub fn keypair(&self) -> Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>> {
+        self.shared.keypair.clone()
+    }
     pub fn client(&self) -> &dyn ChainClient {
         self.shared.client.as_ref()
     }

--- a/sgwallet/tests/rpc_chain_test_helper.rs
+++ b/sgwallet/tests/rpc_chain_test_helper.rs
@@ -10,6 +10,8 @@ pub fn run_with_rpc_client<F, T>(mut f: F) -> T
 where
     F: FnMut(Arc<dyn ChainClient>) -> T,
 {
+    libra_logger::try_init_for_testing();
+    let _ = slog_stdlog::init();
     let (config, _logger, _handler) = sgchain::main_node::run_node(None, false, true);
     info!("node is running.");
     let ac_port = config.admission_control.admission_control_service_port;

--- a/sgwallet/tests/test_channel_challenge.rs
+++ b/sgwallet/tests/test_channel_challenge.rs
@@ -21,7 +21,7 @@ use libra_types::{
 use rpc_chain_test_helper::run_with_rpc_client;
 use sgwallet::{
     chain_watcher::{ChainWatcher, Interest, TransactionWithInfo},
-    wallet::Wallet,
+    wallet::WalletHandle,
 };
 use std::{sync::Arc, time::Duration};
 
@@ -60,7 +60,10 @@ fn run_test_channel_lock_and_then_timeout() {
 }
 }
 
-async fn test_channel_lock_and_resolve(sender: Arc<Wallet>, receiver: Arc<Wallet>) -> Result<()> {
+async fn test_channel_lock_and_resolve(
+    sender: Arc<WalletHandle>,
+    receiver: Arc<WalletHandle>,
+) -> Result<()> {
     let _sender_init_balance = sender.balance()?;
     let _receiver_init_balance = receiver.balance()?;
     let _gas = common::open_channel(sender.clone(), receiver.clone(), 10000, 10000).await?;
@@ -140,7 +143,10 @@ async fn test_channel_lock_and_resolve(sender: Arc<Wallet>, receiver: Arc<Wallet
     Ok(())
 }
 
-async fn test_channel_lock_and_challenge(sender: Arc<Wallet>, receiver: Arc<Wallet>) -> Result<()> {
+async fn test_channel_lock_and_challenge(
+    sender: Arc<WalletHandle>,
+    receiver: Arc<WalletHandle>,
+) -> Result<()> {
     let _sender_init_balance = sender.balance()?;
     let _receiver_init_balance = receiver.balance()?;
     let _gas = common::open_channel(sender.clone(), receiver.clone(), 10000, 10000).await?;
@@ -207,7 +213,10 @@ async fn test_channel_lock_and_challenge(sender: Arc<Wallet>, receiver: Arc<Wall
     Ok(())
 }
 
-async fn test_channel_lock_and_timeout(sender: Arc<Wallet>, receiver: Arc<Wallet>) -> Result<()> {
+async fn test_channel_lock_and_timeout(
+    sender: Arc<WalletHandle>,
+    receiver: Arc<WalletHandle>,
+) -> Result<()> {
     let _sender_init_balance = sender.balance()?;
     let _receiver_init_balance = receiver.balance()?;
     let _gas = common::open_channel(sender.clone(), receiver.clone(), 10000, 10000).await?;

--- a/sgwallet/tests/transfer/mod.rs
+++ b/sgwallet/tests/transfer/mod.rs
@@ -4,10 +4,13 @@
 use super::common::{open_channel, receive_payment, send_payment};
 use anyhow::Result;
 use libra_crypto::HashValue;
-use sgwallet::wallet::Wallet;
+use sgwallet::wallet::WalletHandle;
 use std::sync::Arc;
 
-pub async fn transfer_htlc(sender_wallet: Arc<Wallet>, receiver_wallet: Arc<Wallet>) -> Result<()> {
+pub async fn transfer_htlc(
+    sender_wallet: Arc<WalletHandle>,
+    receiver_wallet: Arc<WalletHandle>,
+) -> Result<()> {
     let fund_amount = 10000;
     open_channel(
         sender_wallet.clone(),

--- a/sgwallet/tests/wallet_test_helper/mod.rs
+++ b/sgwallet/tests/wallet_test_helper/mod.rs
@@ -12,7 +12,7 @@ use libra_types::{
 use sgchain::{client_state_view::ClientStateView, star_chain_client::ChainClient};
 use sgcompiler::{Compiler, StateViewModuleLoader};
 use sgtypes::script_package::ChannelScriptPackage;
-use sgwallet::{get_channel_events, wallet::Wallet, ChannelChangeEvent};
+use sgwallet::{get_channel_events, wallet::WalletHandle, ChannelChangeEvent};
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -27,8 +27,8 @@ use std::{
 //}
 
 pub async fn test_channel_event_watcher_async(
-    sender_wallet: Arc<Wallet>,
-    receiver_wallet: Arc<Wallet>,
+    sender_wallet: Arc<WalletHandle>,
+    receiver_wallet: Arc<WalletHandle>,
 ) -> Result<()> {
     let sender_fund_amount = 10000;
     let receiver_fund_amount = 10000;
@@ -86,8 +86,8 @@ pub async fn test_channel_event_watcher_async(
 }
 
 pub async fn test_wallet_async(
-    sender_wallet: Arc<Wallet>,
-    receiver_wallet: Arc<Wallet>,
+    sender_wallet: Arc<WalletHandle>,
+    receiver_wallet: Arc<WalletHandle>,
 ) -> Result<()> {
     let sender_fund_amount: u64 = 0;
     let receiver_fund_amount: u64 = 0;
@@ -220,8 +220,8 @@ fn get_test_case_path(case_name: &str) -> PathBuf {
 }
 
 pub async fn deploy_custom_module_and_script(
-    wallet1: Arc<Wallet>,
-    wallet2: Arc<Wallet>,
+    wallet1: Arc<WalletHandle>,
+    wallet2: Arc<WalletHandle>,
     test_case: &str,
 ) -> Result<()> {
     compile_and_deploy_module(wallet1.clone(), test_case).await?;
@@ -233,7 +233,7 @@ pub async fn deploy_custom_module_and_script(
     Ok(())
 }
 
-async fn compile_and_deploy_module(wallet: Arc<Wallet>, test_case: &str) -> Result<()> {
+async fn compile_and_deploy_module(wallet: Arc<WalletHandle>, test_case: &str) -> Result<()> {
     let path = get_test_case_path(test_case);
     let module_source = std::fs::read_to_string(path.join("module.mvir"))?;
 
@@ -246,7 +246,7 @@ async fn compile_and_deploy_module(wallet: Arc<Wallet>, test_case: &str) -> Resu
     Ok(())
 }
 
-fn compile_package(wallet: Arc<Wallet>, test_case: &str) -> Result<ChannelScriptPackage> {
+fn compile_package(wallet: Arc<WalletHandle>, test_case: &str) -> Result<ChannelScriptPackage> {
     let path = get_test_case_path(test_case);
 
     let client_state_view = ClientStateView::new(None, wallet.client());


### PR DESCRIPTION
wallet start now is a async methods, and param executor is not needed anymore.
This will make code easy to read, and will embrace async in one runtime.
