### PR TITLE
refactor: add channel stm abstraction

### DIFF
--- a/node/node_internal/src/invoice.rs
+++ b/node/node_internal/src/invoice.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct InvoiceManager {
-    r_hash_map: Arc<Mutex<HashMap<Vec<u8>, (Vec<u8>)>>>,
+    r_hash_map: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
     r_hash_previous_hop_map: Arc<Mutex<HashMap<Vec<u8>, AccountAddress>>>,
 }
 

--- a/sgstorage/src/channel_store.rs
+++ b/sgstorage/src/channel_store.rs
@@ -8,7 +8,7 @@ use crate::pending_txn_store::PendingTxnStore;
 use crate::schema::participant_public_key_schema::ParticipantPublicKeySchema;
 use crate::schema_db::SchemaDB;
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{ensure, Result};
 use itertools::Itertools;
 use libra_crypto::ed25519::Ed25519PublicKey;
 use libra_crypto::hash::CryptoHash;
@@ -269,12 +269,6 @@ where
         pending_txn: PendingTransaction,
         persist: bool,
     ) -> Result<()> {
-        let cur_pending_txn = self.get_pending_txn();
-        if let Some(cur) = cur_pending_txn {
-            if cur.newer_than(&pending_txn) {
-                bail!("cannot save pending txn, state invalid");
-            }
-        }
         if persist {
             let mut sb = SchemaBatch::new();
             self.pending_txn_store

--- a/sgwallet/src/channel/channel.rs
+++ b/sgwallet/src/channel/channel.rs
@@ -1005,15 +1005,9 @@ impl Channel {
 
         let time_lock = lock_by.time_lock;
 
-        let watch_tag = {
-            let mut t = self.channel_address().to_vec();
-            t.extend("lock".as_bytes());
-            t
-        };
-
         let mut timeout_receiver = self
             .chain_txn_watcher
-            .add_interest(watch_tag, Box::new(move |txn| txn.block_height > time_lock))
+            .add_interest(Box::new(move |txn| txn.block_height > time_lock))
             .await?;
         let mut self_ref = self.actor_ref(ctx).await;
 

--- a/sgwallet/src/channel/channel.rs
+++ b/sgwallet/src/channel/channel.rs
@@ -1,20 +1,15 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-use crate::wallet::ChannelNotifyEvent;
 use crate::{
     channel::{
         access_local, channel_event_stream::ChannelEventStream, AccessingResource,
         ApplyCoSignedTxn, ApplyPendingTxn, ApplySoloTxn, CancelPendingTxn, Channel, ChannelEvent,
-        CollectProposalWithSigs, Execute, ForceTravel, GetPendingTxn, GrantProposal,
+        CollectProposalWithSigs, Execute, GetPendingTxn, GrantProposal,
     },
-    channel_state_view::ChannelStateView,
     utils::contract::{
-        challenge_channel_action, close_channel_action, parse_channel_event, resolve_channel_action,
+        channel_challenge_name, channel_close_name, channel_resolve_name, parse_channel_event,
     },
-    wallet::{
-        execute_transaction, submit_transaction, txn_expiration, GAS_UNIT_PRICE,
-        MAX_GAS_AMOUNT_OFFCHAIN, MAX_GAS_AMOUNT_ONCHAIN,
-    },
+    wallet::{submit_transaction, watch_transaction, ChannelNotifyEvent},
 };
 use anyhow::{bail, ensure, format_err, Result};
 use async_trait::async_trait;
@@ -24,46 +19,30 @@ use coerce_rt::actor::{
     Actor, ActorRef,
 };
 use futures::StreamExt;
-use libra_crypto::{
-    ed25519::{Ed25519PublicKey, Ed25519Signature},
-    hash::CryptoHash,
-    SigningKey, VerifyingKey,
-};
+use libra_crypto::hash::CryptoHash;
 use libra_logger::prelude::*;
-use libra_state_view::StateView;
 use libra_types::{
-    access_path::{AccessPath, DataPath},
     account_address::AccountAddress,
-    channel::{
-        ChannelChallengeBy, ChannelLockedBy, ChannelMirrorResource,
-        ChannelParticipantAccountResource, ChannelResource, Witness, WitnessData,
-    },
+    account_config::{account_module_name, core_code_address},
+    channel::ChannelResource,
     contract_event::{ContractEvent, EventWithProof},
-    identifier::Identifier,
-    language_storage::ModuleId,
-    libra_resource::{make_resource, LibraResource},
     transaction::{
-        ChannelTransactionPayload, ChannelTransactionPayloadBody, RawTransaction, ScriptAction,
         SignedTransaction, Transaction, TransactionArgument, TransactionInfo,
-        TransactionListWithProof, TransactionOutput, TransactionPayload, Version,
+        TransactionListWithProof, TransactionOutput, TransactionPayload, TransactionWithProof,
     },
-    vm_error::StatusCode,
     write_set::WriteSet,
 };
-use serde::de::DeserializeOwned;
-use sgchain::client_state_view::ClientStateView;
 use sgtypes::{
     applied_channel_txn::AppliedChannelTxn,
     channel::ChannelState,
-    channel_transaction::{ChannelOp, ChannelTransaction, ChannelTransactionProposal},
+    channel_transaction::{ChannelOp, ChannelTransaction},
     channel_transaction_sigs::ChannelTransactionSigs,
     channel_transaction_to_commit::ChannelTransactionToCommit,
-    pending_txn::PendingTransaction,
+    pending_txn::{PendingTransaction, ProposalLifecycle},
     signed_channel_transaction::SignedChannelTransaction,
     signed_channel_transaction_with_proof::SignedChannelTransactionWithProof,
 };
-use std::{collections::BTreeMap, time::Duration};
-use vm::gas_schedule::GasAlgebra;
+use std::collections::BTreeMap;
 
 //impl Channel {
 //    #[allow(dead_code)]
@@ -107,13 +86,16 @@ impl Actor for Channel {
 
         let mut myself = self.actor_ref(ctx).await;
 
-        if let Some(proposal) = to_be_apply {
-            if let Err(_) = myself.notify(ApplyPendingTxn { proposal }).await {
+        if let Some(_) = to_be_apply {
+            if let Err(_) = myself.notify(ApplyPendingTxn).await {
                 panic!("should not happen");
             }
         }
 
-        let start_number = self.channel_resource().map(|r| r.event_handle().count());
+        let start_number = self
+            .stm
+            .channel_resource()
+            .map(|r| r.event_handle().count());
         if let Some(c) = start_number {
             let channel_event_stream = ChannelEventStream::new_from_chain_client(
                 self.chain_client.clone(),
@@ -151,23 +133,23 @@ impl Handler<Execute> for Channel {
         _ctx: &mut ActorHandlerContext,
     ) -> <Execute as Message>::Result {
         let Execute { channel_op, args } = message;
-        debug!(
-            "{} - execute txn, op: {:?}, args: {:?}",
-            &self.account_address, &channel_op, &args
-        );
-        // generate proposal
-        let proposal = self.generate_proposal(channel_op, args)?;
-
-        // execute proposal to get txn payload and txn witness data for later use
-        let (_payload_body, _payload_body_signature, output) = self.execute_proposal(&proposal)?;
-
-        self.do_grant_proposal(proposal.clone(), output.clone(), BTreeMap::new())?;
-
-        let pending = self.pending_txn().expect("pending txn must exists");
-        let user_sigs = pending
-            .get_signature(&self.account_address)
-            .expect("user signature must exists");
-        Ok((proposal, user_sigs, output))
+        let proposal = self.stm.generate_proposal(channel_op, args)?;
+        let mut pending_txn = self.pending_txn();
+        self.stm.handle_new_proposal(&mut pending_txn, proposal)?;
+        debug_assert!(pending_txn.is_some());
+        let mut pending_txn = pending_txn.unwrap();
+        let my_signature = self
+            .stm
+            .generate_txn_sigs(&pending_txn.proposal().channel_txn, pending_txn.output())?;
+        let channel_txn_id = CryptoHash::hash(&pending_txn.proposal().channel_txn);
+        self.stm.handle_proposal_signature(
+            &mut pending_txn,
+            channel_txn_id,
+            my_signature.clone(),
+        )?;
+        self.save_pending_txn(pending_txn.clone())?;
+        let (proposal, output, _) = pending_txn.into();
+        Ok((proposal, my_signature, output))
     }
 }
 
@@ -209,66 +191,32 @@ impl Handler<CollectProposalWithSigs> for Channel {
                 }
             }
         }
+        let mut pending_txn = self.pending_txn();
+        self.stm.handle_new_proposal(&mut pending_txn, proposal)?;
+        debug_assert!(pending_txn.is_some());
 
-        self.verify_proposal(&proposal)?;
+        let mut pending_txn = pending_txn.unwrap();
+        let txn_hash = CryptoHash::hash(&pending_txn.proposal().channel_txn);
+        self.stm
+            .handle_proposal_signature(&mut pending_txn, txn_hash, sigs)?;
 
-        let mut verified_signatures = BTreeMap::new();
-        let (payload_body, _payload_body_signature, output) = match self.pending_txn() {
-            None => self.execute_proposal(&proposal)?,
-            Some(p) if p.is_negotiating() => {
-                let (local_proposal, output, signatures) = p.into();
+        if self.stm.can_auto_sign_pending_proposal(&pending_txn)? {
+            debug!(
+                "{}/{} - auto sign channel txn",
+                &self.account_address, &self.channel_address
+            );
 
-                ensure!(
-                    CryptoHash::hash(&proposal.channel_txn)
-                        == CryptoHash::hash(&local_proposal.channel_txn),
-                    format_err!("channel txn conflict with local")
-                );
-                ensure!(
-                    &proposal.proposer_public_key == &local_proposal.proposer_public_key,
-                    format_err!("txn proposer public_key conflict with local")
-                );
-                debug_assert_eq!(
-                    &local_proposal.proposer_signature,
-                    &proposal.proposer_signature
-                );
-                verified_signatures = signatures;
+            let my_signature = self
+                .stm
+                .generate_txn_sigs(&pending_txn.proposal().channel_txn, pending_txn.output())?;
+            let proposal_hash = CryptoHash::hash(&pending_txn.proposal().channel_txn);
+            self.stm
+                .handle_proposal_signature(&mut pending_txn, proposal_hash, my_signature)?;
+        }
 
-                let (payload_body, payload_body_signature) =
-                    self.build_and_sign_channel_txn_payload_body(&proposal.channel_txn)?;
-                (payload_body, payload_body_signature, output)
-            }
-            Some(p) => match p.get_signature(&self.account_address) {
-                Some(s) => return Ok(Some(s)),
-                None => {
-                    panic!("should already give out user signature");
-                }
-            },
-        };
+        self.save_pending_txn(pending_txn.clone())?;
 
-        self.verify_txn_sigs(&payload_body, &output, &sigs)?;
-
-        verified_signatures.insert(sigs.address, sigs);
-
-        // if the output modifies user's channel state, permission need to be granted by user.
-        // it cannot be auto-signed.
-        let can_auto_signed = !is_participant_channel_resource_modified(
-            self.witness_data().write_set(),
-            output.write_set(),
-            &self.account_address,
-        );
-
-        debug!(
-            "{}/{} - auto sign({}) channel txn: {:?}",
-            &self.account_address, &self.channel_address, can_auto_signed, &payload_body,
-        );
-        if !verified_signatures.contains_key(&self.account_address) && can_auto_signed {
-            self.do_grant_proposal(proposal, output, verified_signatures)?;
-        } else {
-            self.save_pending_txn(proposal, output, verified_signatures)?;
-        };
-
-        let pending = self.pending_txn().expect("pending txn must exists");
-        let user_sigs = pending.get_signature(&self.account_address);
+        let user_sigs = pending_txn.get_signature(&self.account_address);
         Ok(user_sigs)
     }
 }
@@ -278,46 +226,37 @@ impl Handler<GrantProposal> for Channel {
     async fn handle(
         &mut self,
         message: GrantProposal,
-        ctx: &mut ActorHandlerContext,
+        _ctx: &mut ActorHandlerContext,
     ) -> <GrantProposal as Message>::Result {
-        let GrantProposal {
-            channel_txn_id,
-            grant,
-        } = message;
+        let GrantProposal { channel_txn_id } = message;
         debug!(
-            "{} grant({}) proposal {}",
-            &self.account_address, grant, &channel_txn_id
+            "{} grant proposal {}",
+            &self.account_address, &channel_txn_id
         );
-
         let pending_txn = self.pending_txn();
         ensure!(pending_txn.is_some(), "no pending txn");
-        let pending_txn = pending_txn.unwrap();
-        ensure!(
-            !pending_txn.consensus_reached(),
-            "pending txn is already consensus_reached"
-        );
-        let (proposal, output, signatures) = pending_txn.into();
+        let mut pending_txn = pending_txn.unwrap();
+        let proposal = pending_txn.proposal();
         if channel_txn_id != CryptoHash::hash(&proposal.channel_txn) {
             let err = format_err!("channel_txn_id conflict with local pending txn");
             return Err(err);
         }
-        if grant {
-            // maybe already grant the proposal
-            if !signatures.contains_key(&self.account_address) {
-                self.do_grant_proposal(proposal, output, signatures)?;
-            }
-            let pending = self.pending_txn().expect("pending txn must exists");
-            let user_sigs = pending
-                .get_signature(&self.account_address)
-                .expect("user signature must exists");
-            Ok(Some(user_sigs))
-        } else {
-            self.clear_pending_txn()?;
-            if proposal.channel_txn.operator().is_open() {
-                ctx.set_status(ActorStatus::Stopping);
-            }
-            Ok(None)
-        }
+        ensure!(
+            !pending_txn.consensus_reached(),
+            "pending txn is already consensus_reached"
+        );
+
+        let my_signature = self
+            .stm
+            .generate_txn_sigs(&pending_txn.proposal().channel_txn, pending_txn.output())?;
+        let proposal_hash = CryptoHash::hash(&pending_txn.proposal().channel_txn);
+        self.stm.handle_proposal_signature(
+            &mut pending_txn,
+            proposal_hash,
+            my_signature.clone(),
+        )?;
+        self.save_pending_txn(pending_txn)?;
+        Ok(my_signature)
     }
 }
 
@@ -329,24 +268,21 @@ impl Handler<CancelPendingTxn> for Channel {
         ctx: &mut ActorHandlerContext,
     ) -> <CancelPendingTxn as Message>::Result {
         let CancelPendingTxn { channel_txn_id } = message;
-        debug!(
-            "{} cancel pending proposal {}",
-            &self.account_address, &channel_txn_id
-        );
+
         let pending_txn = self.pending_txn();
         ensure!(pending_txn.is_some(), "no pending txn");
         let pending_txn = pending_txn.unwrap();
-        ensure!(
-            !pending_txn.consensus_reached(),
-            "pending txn is already consensus_reached"
-        );
-        let (proposal, _output, _signature) = pending_txn.into();
+        let proposal = pending_txn.proposal();
         if channel_txn_id != CryptoHash::hash(&proposal.channel_txn) {
             let err = format_err!("channel_txn_id conflict with local pending txn");
             return Err(err);
         }
-        self.clear_pending_txn()?;
+        ensure!(
+            !pending_txn.consensus_reached(),
+            "pending txn is already consensus_reached"
+        );
 
+        self.clear_pending_txn()?;
         if proposal.channel_txn.operator().is_open() {
             ctx.set_status(ActorStatus::Stopping);
         }
@@ -358,106 +294,43 @@ impl Handler<CancelPendingTxn> for Channel {
 impl Handler<ApplyPendingTxn> for Channel {
     async fn handle(
         &mut self,
-        message: ApplyPendingTxn,
+        _message: ApplyPendingTxn,
         _ctx: &mut ActorHandlerContext,
     ) -> <ApplyPendingTxn as Message>::Result {
         debug!("{} apply pending txn", self.account_address);
-        let ApplyPendingTxn { proposal } = message;
 
-        if let Some(_signed_txn) =
-            self.check_applied(proposal.channel_txn.channel_sequence_number())?
-        {
-            warn!(
-                "txn {} already applied!",
-                &CryptoHash::hash(&proposal.channel_txn)
-            );
-            //            let res = Ok::<u64, Error>(if signed_txn.proof.transaction_info().travel() {
-            //                signed_txn.proof.transaction_info().gas_used()
-            //            } else {
-            //                0
-            //            });
-            //
-            return Ok(None);
-        }
-
-        ensure!(self.pending_txn().is_some(), "should have txn to apply");
-        let pending_txn = self.pending_txn().unwrap();
+        let pending_txn = self.pending_txn();
+        ensure!(pending_txn.is_some(), "should have txn to apply");
+        let mut pending_txn = pending_txn.unwrap();
         ensure!(
-            pending_txn.consensus_reached(),
-            "txn should have been consensus_reached"
+            pending_txn.lifecycle() == ProposalLifecycle::Negotiating
+                || pending_txn.lifecycle() == ProposalLifecycle::Agreed,
+            "cannot apply pending txn which is already applying or traveling",
         );
-        let (proposal, output, signatures) = pending_txn.into();
 
-        if !output.is_travel_txn() {
-            self.apply(proposal.channel_txn, output, signatures)?;
-            return Ok(None);
+        self.stm.handle_apply_proposal(&mut pending_txn)?;
+
+        let proposal_lifecycle = pending_txn.lifecycle();
+        match proposal_lifecycle {
+            ProposalLifecycle::Applying => {
+                let (proposal, output, signatures) = pending_txn.into();
+                self.apply(proposal.channel_txn, output, signatures)?;
+                return Ok(None);
+            }
+            ProposalLifecycle::Traveling => {
+                let channel_txn = &pending_txn.proposal().channel_txn;
+                if self.account_address == channel_txn.proposer() {
+                    let signed_txn = self.stm.build_channel_transaction_payload(&pending_txn)?;
+                    submit_transaction(self.chain_client.as_ref(), signed_txn).await?;
+                }
+                let txn_sender = channel_txn.proposer();
+                let seq_number = channel_txn.sequence_number();
+
+                self.save_pending_txn(pending_txn)?;
+                Ok(Some((txn_sender, seq_number)))
+            }
+            _ => unreachable!(),
         }
-
-        let channel_txn = &proposal.channel_txn;
-        if self.account_address == channel_txn.proposer() {
-            let max_gas_amount = std::cmp::min(
-                (output.gas_used() as f64 * 1.1) as u64,
-                MAX_GAS_AMOUNT_ONCHAIN,
-            );
-            let (payload_body, _) = self.build_and_sign_channel_txn_payload_body(channel_txn)?;
-
-            let signed_txn = self.build_raw_txn_from_channel_txn(
-                payload_body,
-                &channel_txn,
-                Some(&signatures),
-                max_gas_amount,
-            )?;
-
-            submit_transaction(self.chain_client.as_ref(), signed_txn).await?;
-        }
-
-        let txn_sender = channel_txn.proposer();
-        let seq_number = channel_txn.sequence_number();
-        // savce proposal as applying
-        let mut pending_proposal = PendingTransaction::new(proposal, output, signatures);
-        pending_proposal.set_applying();
-        self.store.save_pending_txn(pending_proposal, true)?;
-
-        Ok(Some((txn_sender, seq_number)))
-        //        self.watch_and_travel_txn_async(ctx, txn_sender, seq_number)
-        //            .await
-    }
-}
-
-#[async_trait]
-impl Handler<ForceTravel> for Channel {
-    async fn handle(
-        &mut self,
-        _message: ForceTravel,
-        _ctx: &mut ActorHandlerContext,
-    ) -> <ForceTravel as Message>::Result {
-        debug!("{} force travel txn", self.account_address);
-        ensure!(self.pending_txn().is_some(), "should have txn to apply");
-        let pending_txn = self.pending_txn().unwrap();
-        ensure!(
-            !pending_txn.consensus_reached(),
-            "txn should not be consensus_reached"
-        );
-        let (proposal, output, _signatures) = pending_txn.into();
-        let channel_txn = &proposal.channel_txn;
-        ensure!(
-            self.account_address == channel_txn.proposer(),
-            "solo should only use myself's proposal"
-        );
-
-        let max_gas_amount = std::cmp::min(
-            (output.gas_used() as f64 * 1.1) as u64,
-            MAX_GAS_AMOUNT_ONCHAIN,
-        );
-        let action =
-            self.channel_op_to_action(channel_txn.operator(), channel_txn.args().to_vec())?;
-
-        let signed_txn = self.solo_txn(action, Some(max_gas_amount)).await?;
-
-        let txn_sender = signed_txn.sender();
-        let seq_number = signed_txn.sequence_number();
-
-        Ok((txn_sender, seq_number))
     }
 }
 
@@ -474,8 +347,12 @@ impl Handler<AccessingResource> for Channel {
             self.account_address,
             path.data_path()
         );
-        access_local(self.witness_data().write_set(), &self.channel_state, &path)
-            .map(|d| d.map(|o| o.to_vec()))
+        access_local(
+            self.stm.witness().write_set(),
+            self.stm.channel_state(),
+            &path,
+        )
+        .map(|d| d.map(|o| o.to_vec()))
     }
 }
 
@@ -528,7 +405,7 @@ impl Handler<ApplyCoSignedTxn> for Channel {
         debug_assert!(channel_txn_payload.is_authorized());
 
         let txn_channel_seq_number = channel_txn_payload.witness().channel_sequence_number();
-        let local_channel_seq_number = self.channel_sequence_number();
+        let local_channel_seq_number = self.stm.channel_sequence_number();
         // compare the new txn's witness sequence number with local sequence_number
         // if equal, it means new txn committed on-chain, but I don't aware.
         // if less by only one, maybe proposer didn't receive my signature, and he proposed the txn on-chain,
@@ -575,6 +452,7 @@ impl Handler<ApplyCoSignedTxn> for Channel {
         self.apply_travel(version, signed_txn.clone(), txn_info, events)?;
         // 2. after apply, check channel state
         let channel_resource: ChannelResource = self
+            .stm
             .channel_resource()
             .ok_or(format_err!("channel resource should exists in local"))?;
         debug_assert!(!channel_resource.locked());
@@ -650,7 +528,7 @@ impl Handler<ApplySoloTxn> for Channel {
         debug_assert!(!channel_txn_payload.is_authorized());
 
         let txn_channel_seq_number = channel_txn_payload.witness().channel_sequence_number();
-        let local_channel_seq_number = self.channel_sequence_number();
+        let local_channel_seq_number = self.stm.channel_sequence_number();
         // compare the new txn's witness sequence number with local sequence_number
         // if equal, it means new txn committed on-chain, but I don't aware.
         // if less by only one, maybe proposer didn't receive my signature, and he proposed the txn on-chain,
@@ -691,7 +569,18 @@ impl Handler<ApplySoloTxn> for Channel {
                             self.account_address, self.channel_address,
                         );
                         // so I submit a challenge to chain.
-                        let _ = self.solo_txn(challenge_channel_action(), None).await?;
+                        let _ = self
+                            .solo_action(
+                                ctx,
+                                ChannelOp::Action {
+                                    module_address: core_code_address(),
+                                    module_name: account_module_name().as_str().to_string(),
+                                    function_name: channel_challenge_name().as_str().to_string(),
+                                },
+                                vec![],
+                            )
+                            .await?;
+
                         return Ok(0);
                     }
                 }
@@ -704,6 +593,7 @@ impl Handler<ApplySoloTxn> for Channel {
         self.apply_travel(version, signed_txn.clone(), txn_info, events)?;
         // 2. after apply, check channel state
         let channel_resource: ChannelResource = self
+            .stm
             .channel_resource()
             .ok_or(format_err!("channel resource should exists in local"))?;
         if channel_resource.locked() {
@@ -714,7 +604,7 @@ impl Handler<ApplySoloTxn> for Channel {
             if self.account_address == txn_sender {
                 // I lock the channel, wait sender to resolve
                 // TODO: move the timeout check into a timer
-                let time_lock = self.channel_lock_by_resource().unwrap().time_lock;
+                let time_lock = self.stm.channel_lock_by_resource().unwrap().time_lock;
                 debug!(
                     "{}/{} - the solo txn I submitted applied locally, wait receiver timeout, time_lock: {}",
                     self.account_address, self.channel_address, time_lock
@@ -727,7 +617,17 @@ impl Handler<ApplySoloTxn> for Channel {
                 );
 
                 // drop the receiver, as I don't need wait the result
-                let _ = self.solo_txn(resolve_channel_action(), None).await?;
+                let _ = self
+                    .solo_action(
+                        ctx,
+                        ChannelOp::Action {
+                            module_address: core_code_address(),
+                            module_name: account_module_name().as_str().to_string(),
+                            function_name: channel_resolve_name().as_str().to_string(),
+                        },
+                        vec![],
+                    )
+                    .await?;
             }
         } else if channel_resource.closed() {
             // no matter who close ths channel, the channel is done. we just live with it.
@@ -762,7 +662,7 @@ impl Handler<ChannelLockTimeout> for Channel {
     async fn handle(
         &mut self,
         message: ChannelLockTimeout,
-        _ctx: &mut ActorHandlerContext,
+        ctx: &mut ActorHandlerContext,
     ) -> <ChannelLockTimeout as Message>::Result {
         let ChannelLockTimeout {
             block_height,
@@ -781,7 +681,19 @@ impl Handler<ChannelLockTimeout> for Channel {
                 .expect("should contain at least 1 participants")
         };
 
-        let _ = self.solo_txn(close_channel_action(ps), None).await?;
+        // I submit a close channel to chain.
+        let _ = self
+            .solo_action(
+                ctx,
+                ChannelOp::Action {
+                    module_address: core_code_address(),
+                    module_name: account_module_name().as_str().to_string(),
+                    function_name: channel_close_name().as_str().to_string(),
+                },
+                vec![TransactionArgument::Address(ps)],
+            )
+            .await?;
+
         Ok(())
     }
 }
@@ -847,13 +759,13 @@ impl Handler<ChannelStageChange> for Channel {
 
         let ChannelStageChange { version, .. } = message;
 
-        if version <= self.channel_state.version() {
+        if version <= self.stm.channel_state().version() {
             info!(
                 "{}/{}, outdated channel event, version: {}, local version: {}, ignore it",
                 &self.account_address,
                 &self.channel_address,
                 version,
-                self.channel_state.version()
+                self.stm.channel_state().version()
             );
             return Ok(());
         }
@@ -886,19 +798,8 @@ impl Handler<ChannelStageChange> for Channel {
 
         if let TransactionPayload::Channel(cp) = raw_txn.payload() {
             let is_authorized = cp.is_authorized();
-            if is_authorized {
-                let _ = self
-                    .handle(
-                        ApplyCoSignedTxn {
-                            txn,
-                            txn_info,
-                            version,
-                            events,
-                        },
-                        _ctx,
-                    )
-                    .await?;
-            } else {
+            // only watch unauthorized txn sent by participant
+            if !is_authorized && self.account_address != raw_txn.sender() {
                 let _ = self
                     .handle(
                         ApplySoloTxn {
@@ -918,210 +819,51 @@ impl Handler<ChannelStageChange> for Channel {
 }
 
 impl Channel {
-    fn build_solo_txn(
-        &self,
-        action: ScriptAction,
-        max_gas_amount: u64,
-    ) -> Result<SignedTransaction> {
-        let (body, payload_body_signature) =
-            self.propose_channel_action(self.account_address, action)?;
-        let mut signatures = BTreeMap::new();
-        signatures.insert(
-            self.account_address,
-            (self.keypair.public_key.clone(), payload_body_signature),
-        );
-
-        let account_seq_number = self
-            .chain_client
-            .account_sequence_number(&self.account_address)
-            .ok_or(format_err!("account not exists"))?;
-        let txn = self.build_chain_txn(
-            body,
-            Some(signatures),
-            self.account_address,
-            account_seq_number,
-            max_gas_amount,
-            Duration::from_secs(60),
-        )?;
-        Ok(txn)
-    }
-
-    fn channel_view(&self, version: Option<Version>) -> Result<ChannelStateView> {
-        let latest_writeset = self.witness_data().into_write_set();
-        ChannelStateView::new(
-            self.account_address,
-            &self.channel_state,
-            latest_writeset,
-            version,
-            self.chain_client.as_ref(),
-        )
-    }
-
-    fn build_chain_txn(
-        &self,
-        channel_payload_body: ChannelTransactionPayloadBody,
-        txn_signatures: Option<BTreeMap<AccountAddress, (Ed25519PublicKey, Ed25519Signature)>>,
-        txn_sender: AccountAddress,
-        sender_seq_number: u64,
-        max_gas_amount: u64,
-        expiration_time: Duration,
-    ) -> Result<SignedTransaction> {
-        let channel_participant_size = self.participant_addresses.len();
-        let mut participant_keys = self.store.get_participant_keys();
-        let mut sigs = Vec::with_capacity(channel_participant_size);
-        if let Some(signatures) = txn_signatures {
-            for addr in self.participant_addresses.iter() {
-                let sig = signatures.get(&addr);
-                if let Some(s) = sig {
-                    participant_keys.insert(addr.clone(), s.0.clone());
-                }
-                sigs.push(sig.map(|s| s.1.clone()));
-            }
-        }
-
-        if channel_payload_body.witness().channel_sequence_number() == 0 {
-            //            debug_assert!(channel_txn.operator().is_open());
-        } else {
-            debug_assert!(channel_participant_size == participant_keys.len());
-        }
-
-        let keys = participant_keys
-            .into_iter()
-            .map(|p| p.1)
-            .collect::<Vec<_>>();
-
-        let channel_txn_payload = ChannelTransactionPayload::new(channel_payload_body, keys, sigs);
-        let txn_payload = TransactionPayload::Channel(channel_txn_payload);
-
-        let raw_txn = RawTransaction::new(
-            txn_sender,
-            sender_seq_number,
-            txn_payload,
-            max_gas_amount,
-            GAS_UNIT_PRICE,
-            expiration_time,
-        );
-        Ok(raw_txn
-            .sign(&self.keypair.private_key, self.keypair.public_key.clone())?
-            .into_inner())
-    }
-
-    fn build_raw_txn_from_channel_txn(
-        &self,
-        channel_payload_body: ChannelTransactionPayloadBody,
-        channel_txn: &ChannelTransaction,
-        txn_signatures: Option<&BTreeMap<AccountAddress, ChannelTransactionSigs>>,
-        max_gas_amount: u64,
-    ) -> Result<SignedTransaction> {
-        let channel_payload_signatures = txn_signatures.map(|s| {
-            s.into_iter()
-                .map(|(k, v)| {
-                    let ChannelTransactionSigs {
-                        public_key,
-                        channel_payload_signature,
-                        ..
-                    } = v;
-                    (
-                        k.clone(),
-                        (public_key.clone(), channel_payload_signature.clone()),
-                    )
-                })
-                .collect::<BTreeMap<_, _>>()
-        });
-        self.build_chain_txn(
-            channel_payload_body,
-            channel_payload_signatures,
-            channel_txn.proposer(),
-            channel_txn.sequence_number(),
-            max_gas_amount,
-            channel_txn.expiration_time(),
-        )
-    }
-
-    fn propose_channel_action(
-        &self,
-        proposer: AccountAddress,
-        action: ScriptAction,
-    ) -> Result<(ChannelTransactionPayloadBody, Ed25519Signature)> {
-        let body = ChannelTransactionPayloadBody::new(
-            self.channel_address,
-            proposer,
-            action,
-            self.witness_data(),
-        );
-        let body_hash = CryptoHash::hash(&body);
-        let sig = self.keypair.private_key.sign_message(&body_hash);
-        Ok((body, sig))
-    }
-
-    /// build channel txn payload version 2.
-    fn build_and_sign_channel_txn_payload_body(
-        &self,
-        channel_txn: &ChannelTransaction,
-    ) -> Result<(ChannelTransactionPayloadBody, Ed25519Signature)> {
-        let action =
-            self.channel_op_to_action(channel_txn.operator(), channel_txn.args().to_vec())?;
-        self.propose_channel_action(channel_txn.proposer(), action)
-    }
-
-    /// submit solo txn
-    async fn solo_txn(
+    async fn solo_action(
         &mut self,
-        action: ScriptAction,
-        max_gas_amount: Option<u64>,
-    ) -> Result<SignedTransaction> {
-        let max_gas_amount = match max_gas_amount {
-            Some(m) => m,
-            None => {
-                let txn = self.build_solo_txn(action.clone(), MAX_GAS_AMOUNT_OFFCHAIN)?;
-                // TODO: execute using onchain mode.
-                let txn_output = execute_transaction(
-                    &ClientStateView::new(None, self.chain_client.as_ref()),
-                    txn,
-                )?;
-                if txn_output.status().vm_status().major_status != StatusCode::EXECUTED {
-                    bail!(
-                        "execute challenge action offchain error, {:?}",
-                        txn_output.status()
-                    );
-                }
-                std::cmp::min(
-                    (txn_output.gas_used() as f64 * 1.1) as u64,
-                    MAX_GAS_AMOUNT_ONCHAIN,
-                )
+        ctx: &mut ActorHandlerContext,
+        channel_op: ChannelOp,
+        args: Vec<TransactionArgument>,
+    ) -> Result<()> {
+        let _ = self
+            .handle(
+                Execute {
+                    channel_op: channel_op.clone(),
+                    args: args.clone(),
+                },
+                ctx,
+            )
+            .await?;
+
+        let (sender, seq_number) = self
+            .handle(ApplyPendingTxn, ctx)
+            .await?
+            .ok_or(format_err!("expect solo channel txn not applying"))?;
+        let TransactionWithProof {
+            version,
+            transaction,
+            events,
+            proof,
+        } = watch_transaction(self.chain_client.clone(), sender, seq_number).await?;
+        let mut actor_ref = self.actor_ref(ctx).await;
+        tokio::task::spawn(async move {
+            let result = actor_ref
+                .send(ApplySoloTxn {
+                    txn: transaction,
+                    txn_info: proof.transaction_info().clone(),
+                    events: events.unwrap_or_default(),
+                    version,
+                })
+                .await
+                .map_err(|_| format_err!("channel actor gone"))
+                .and_then(|r| r);
+            if let Err(e) = result {
+                error!(
+                    "fail to apply solo txn, {}, {:?}, error: {:?}",
+                    &channel_op, &args, e
+                );
             }
-        };
-
-        let signed_txn = self.build_solo_txn(action, max_gas_amount)?;
-        submit_transaction(self.chain_client.as_ref(), signed_txn.clone()).await?;
-        Ok(signed_txn)
-    }
-
-    fn verify_proposal(&self, proposal: &ChannelTransactionProposal) -> Result<()> {
-        let channel_txn = &proposal.channel_txn;
-        ensure!(
-            self.channel_address == channel_txn.channel_address(),
-            "invalid channel address"
-        );
-        let channel_sequence_number = self.channel_sequence_number();
-        let smallest_allowed_channel_seq_number =
-            channel_sequence_number.checked_sub(1).unwrap_or(0);
-        ensure!(
-            channel_txn.channel_sequence_number() >= smallest_allowed_channel_seq_number
-                && channel_txn.channel_sequence_number() <= channel_sequence_number,
-            "check channel_sequence_number fail."
-        );
-        proposal
-            .proposer_public_key
-            .verify_signature(&CryptoHash::hash(channel_txn), &proposal.proposer_signature)?;
-
-        // TODO: check public key match proposer address
-        if !channel_txn.operator().is_open() {
-            ensure!(
-                self.participant_addresses.contains(&channel_txn.proposer()),
-                "proposer does not belong to the channel"
-            );
-        }
+        });
         Ok(())
     }
 
@@ -1139,18 +881,21 @@ impl Channel {
             write_set: WriteSet::default(),
             gas_used: txn_info.gas_used(),
         };
-        self.tx_applier.apply(txn_to_commit)?;
-
-        self.refresh_channel_state(version)?;
-        Ok(())
-    }
-
-    fn refresh_channel_state(&mut self, version: u64) -> Result<()> {
         let channel_address_state = self
             .chain_client
             .get_account_state(self.channel_address, Some(version))?;
-        self.channel_state = ChannelState::new(self.channel_address, channel_address_state);
+        // NOTICE: apply after we fetch channel state
+        self.tx_applier.apply(txn_to_commit)?;
 
+        // update stm
+        self.stm.advance_state(
+            Some(ChannelState::new(
+                self.channel_address,
+                channel_address_state,
+            )),
+            self.store.get_latest_witness().unwrap_or_default(),
+            self.store.get_participant_keys(),
+        );
         Ok(())
     }
 
@@ -1174,193 +919,24 @@ impl Channel {
 
         // apply txn  also delete pending txn from db
         self.tx_applier.apply(txn_to_commit)?;
+
+        // update stm
+        self.stm.advance_state(
+            None,
+            self.store.get_latest_witness().unwrap_or_default(),
+            self.store.get_participant_keys(),
+        );
         Ok(())
-    }
-
-    fn witness_data(&self) -> Witness {
-        self.store.get_latest_witness().unwrap_or_default()
-    }
-
-    fn channel_sequence_number(&self) -> u64 {
-        let channel_mirror_resource = self
-            .get_local::<ChannelMirrorResource>(&AccessPath::new_for_data_path(
-                self.channel_address,
-                DataPath::channel_resource_path(
-                    self.channel_address,
-                    ChannelMirrorResource::struct_tag(),
-                ),
-            ))
-            .unwrap();
-        match channel_mirror_resource {
-            None => 0,
-            Some(r) => r.channel_sequence_number(),
-        }
-    }
-
-    fn channel_resource(&self) -> Option<ChannelResource> {
-        self.get_local::<ChannelResource>(&AccessPath::new_for_data_path(
-            self.channel_address,
-            DataPath::onchain_resource_path(ChannelResource::struct_tag()),
-        ))
-        .unwrap()
-    }
-    fn channel_lock_by_resource(&self) -> Option<ChannelLockedBy> {
-        self.get_local::<ChannelLockedBy>(&AccessPath::new_for_data_path(
-            self.channel_address,
-            DataPath::onchain_resource_path(ChannelLockedBy::struct_tag()),
-        ))
-        .unwrap()
-    }
-
-    #[allow(dead_code)]
-    fn channel_challenge_by_resource(&self) -> Option<ChannelChallengeBy> {
-        self.get_local::<ChannelChallengeBy>(&AccessPath::new_for_data_path(
-            self.channel_address,
-            DataPath::onchain_resource_path(ChannelChallengeBy::struct_tag()),
-        ))
-        .unwrap()
-    }
-
-    #[allow(dead_code)]
-    fn channel_account_resource(&self) -> Option<ChannelParticipantAccountResource> {
-        self.get_local::<ChannelParticipantAccountResource>(&AccessPath::new_for_data_path(
-            self.channel_address,
-            DataPath::channel_resource_path(
-                self.account_address,
-                ChannelParticipantAccountResource::struct_tag(),
-            ),
-        ))
-        .unwrap()
     }
 
     fn pending_txn(&self) -> Option<PendingTransaction> {
         self.store.get_pending_txn()
     }
 
-    // TODO: should stage is needed?
-
-    //    fn _stage(&self) -> ChannelStage {
-    //        match self.pending_txn() {
-    //            Some(PendingTransaction::WaitForApply { .. }) => ChannelStage::Syncing,
-    //            Some(PendingTransaction::WaitForSig { .. }) => ChannelStage::Pending,
-    //            None => match self.channel_account_resource() {
-    //                Some(resource) => {
-    //                    if resource.closed() {
-    //                        ChannelStage::Closed
-    //                    } else {
-    //                        ChannelStage::Idle
-    //                    }
-    //                }
-    //                None => ChannelStage::Opening,
-    //            },
-    //        }
-    //    }
-    //
-    //    fn _check_stage(&self, expect_stages: Vec<ChannelStage>) -> Result<()> {
-    //        let current_stage = self._stage();
-    //        if !expect_stages.contains(&current_stage) {
-    //            return Err(SgError::new_invalid_channel_stage_error(current_stage).into());
-    //        }
-    //        Ok(())
-    //    }
-
-    fn get_local<T>(&self, access_path: &AccessPath) -> Result<Option<T>>
-    where
-        T: LibraResource + DeserializeOwned,
-    {
-        let witness = self.witness_data();
-        let data = access_local(witness.write_set(), &self.channel_state, access_path)?;
-        data.map(make_resource).transpose()
-    }
-
-    fn generate_proposal(
-        &self,
-        channel_op: ChannelOp,
-        args: Vec<TransactionArgument>,
-    ) -> Result<ChannelTransactionProposal> {
-        // TODO: state view should be shared to reduce fetching account state from layer1.
-        let state_view = self.channel_view(None)?;
-
-        // account state already cached in state view
-        let account_seq_number = {
-            let account_resource_blob = state_view
-                .get(&AccessPath::new_for_account_resource(self.account_address))?
-                .ok_or(format_err!(
-                    "account resource for {} not exists on chain",
-                    self.account_address,
-                ))?;
-            let account_resource =
-                sgtypes::account_resource_ext::from_bytes(&account_resource_blob)?;
-            account_resource.sequence_number()
-        };
-
-        let chain_version = state_view.version();
-        // build channel_transaction first
-        let channel_txn = ChannelTransaction::new(
-            chain_version,
-            self.channel_address,
-            self.channel_sequence_number(),
-            channel_op,
-            args,
-            self.account_address,
-            account_seq_number,
-            txn_expiration(),
-        );
-        let channel_txn_hash = CryptoHash::hash(&channel_txn);
-        let channel_txn_signature = self.keypair.private_key.sign_message(&channel_txn_hash);
-
-        let proposal = ChannelTransactionProposal {
-            channel_txn,
-            proposer_public_key: self.keypair.public_key.clone(),
-            proposer_signature: channel_txn_signature,
-        };
-        Ok(proposal)
-    }
-
-    fn execute_proposal(
-        &self,
-        proposal: &ChannelTransactionProposal,
-    ) -> Result<(
-        ChannelTransactionPayloadBody,
-        Ed25519Signature,
-        TransactionOutput,
-    )> {
-        let channel_txn = &proposal.channel_txn;
-        let (payload_body, payload_body_signature) =
-            self.build_and_sign_channel_txn_payload_body(channel_txn)?;
-
-        let output = {
-            // create mocked txn to execute
-            // execute txn on offchain vm, should mock sender and receiver signature with a local
-            // keypair. the vm will skip signature check on offchain vm.
-            let txn = self.build_raw_txn_from_channel_txn(
-                payload_body.clone(),
-                channel_txn,
-                None,
-                MAX_GAS_AMOUNT_OFFCHAIN,
-            )?;
-
-            let version = channel_txn.version();
-            let state_view = self.channel_view(Some(version))?;
-            execute_transaction(&state_view, txn)?
-        };
-
-        // check output gas
-        let gas_used = output.gas_used();
-        if gas_used > vm::gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS.get() {
-            warn!(
-                "GasUsed {} > gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS {}",
-                gas_used,
-                vm::gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS.get()
-            );
-        }
-
-        Ok((payload_body, payload_body_signature, output))
-    }
     fn check_applied(
         &self,
         channel_sequence_number: u64,
-    ) -> Result<Option<(SignedChannelTransactionWithProof)>> {
+    ) -> Result<Option<SignedChannelTransactionWithProof>> {
         if let Some(info) = self.store.get_startup_info()? {
             if channel_sequence_number > info.latest_version {
                 Ok(None)
@@ -1379,124 +955,16 @@ impl Channel {
         }
     }
 
-    fn generate_txn_sigs(
-        &self,
-        channel_txn: &ChannelTransaction,
-        output: &TransactionOutput,
-    ) -> Result<ChannelTransactionSigs> {
-        let (_, payload_body_signature) =
-            self.build_and_sign_channel_txn_payload_body(channel_txn)?;
-
-        let ws = if output.is_travel_txn() {
-            WriteSet::default()
-        } else {
-            output.write_set().clone()
-        };
-        let witness_data = WitnessData::new(self.channel_sequence_number() + 1, ws);
-        let witness_data_hash = CryptoHash::hash(&witness_data);
-        let witness_data_signature = self.keypair.private_key.sign_message(&witness_data_hash);
-
-        let travel_output_witness_signature = if output.is_travel_txn() {
-            let txn_output_witness_data = WitnessData::new(
-                self.channel_sequence_number() + 1,
-                output.write_set().clone(),
-            );
-            Some(
-                self.keypair
-                    .private_key
-                    .sign_message(&CryptoHash::hash(&txn_output_witness_data)),
-            )
-        } else {
-            None
-        };
-
-        let generated_sigs = ChannelTransactionSigs::new(
-            self.account_address,
-            self.keypair.public_key.clone(),
-            payload_body_signature,
-            witness_data_hash,
-            witness_data_signature,
-            travel_output_witness_signature,
-        );
-
-        Ok(generated_sigs)
-    }
-
-    fn verify_txn_sigs(
-        &self,
-        payload_body: &ChannelTransactionPayloadBody,
-        output: &TransactionOutput,
-        channel_txn_sigs: &ChannelTransactionSigs,
-    ) -> Result<()> {
-        channel_txn_sigs.public_key.verify_signature(
-            &CryptoHash::hash(payload_body),
-            &channel_txn_sigs.channel_payload_signature,
-        )?;
-
-        let ws = if output.is_travel_txn() {
-            WriteSet::default()
-        } else {
-            output.write_set().clone()
-        };
-        let witness_data = WitnessData::new(self.channel_sequence_number() + 1, ws);
-
-        ensure!(
-            &CryptoHash::hash(&witness_data) == &channel_txn_sigs.witness_data_hash,
-            "witness hash mismatched"
-        );
-        channel_txn_sigs.public_key.verify_signature(
-            &channel_txn_sigs.witness_data_hash,
-            &channel_txn_sigs.witness_data_signature,
-        )?;
-
-        if output.is_travel_txn() {
-            match &channel_txn_sigs.travel_output_witness_signature {
-                None => bail!("travel txn should have signer's signature on output"),
-                Some(signature) => {
-                    let txn_output_witness_data = WitnessData::new(
-                        self.channel_sequence_number() + 1,
-                        output.write_set().clone(),
-                    );
-                    channel_txn_sigs
-                        .public_key
-                        .verify_signature(&CryptoHash::hash(&txn_output_witness_data), signature)?;
-                }
+    fn save_pending_txn(&mut self, pending_txn: PendingTransaction) -> Result<()> {
+        if let Some(cur) = self.store.get_pending_txn() {
+            // already in storage
+            if &cur == &pending_txn {
+                return Ok(());
+            } else if cur.newer_than(&pending_txn) {
+                bail!("cannot save pending txn, state invalid");
             }
         }
 
-        Ok(())
-    }
-
-    /// Grant the proposal and save it into pending txn
-    fn do_grant_proposal(
-        &mut self,
-        proposal: ChannelTransactionProposal,
-        output: TransactionOutput,
-        mut signatures: BTreeMap<AccountAddress, ChannelTransactionSigs>,
-    ) -> Result<()> {
-        let user_sigs = self.generate_txn_sigs(&proposal.channel_txn, &output)?;
-        signatures.insert(user_sigs.address, user_sigs.clone());
-        debug!(
-            "user {:?} add signature to txn {}",
-            self.account_address,
-            CryptoHash::hash(&proposal.channel_txn),
-        );
-        self.save_pending_txn(proposal, output, signatures)
-    }
-
-    fn save_pending_txn(
-        &mut self,
-        proposal: ChannelTransactionProposal,
-        output: TransactionOutput,
-        signatures: BTreeMap<AccountAddress, ChannelTransactionSigs>,
-    ) -> Result<()> {
-        let mut pending_txn = PendingTransaction::new(proposal, output, signatures);
-        if pending_txn.try_reach_consensus(&self.participant_addresses) {
-            info!(
-                "wallet {}: consensus on channel {} is reached",
-                self.account_address, self.channel_address,
-            );
-        }
         // always persist pending txn
         self.store.save_pending_txn(pending_txn, true)?;
         Ok(())
@@ -1514,6 +982,7 @@ impl Channel {
     }
     async fn watch_channel_lock_timeout(&self, ctx: &mut ActorHandlerContext) -> Result<()> {
         let lock_by = self
+            .stm
             .channel_lock_by_resource()
             .expect("expect lock_by resource exists");
 
@@ -1559,70 +1028,9 @@ impl Channel {
     fn clear_pending_txn(&self) -> Result<()> {
         self.store.clear_pending_txn()
     }
-
-    fn channel_op_to_action(
-        &self,
-        op: &ChannelOp,
-        args: Vec<TransactionArgument>,
-    ) -> Result<ScriptAction> {
-        match op {
-            ChannelOp::Open => {
-                let module_id =
-                    ModuleId::new(AccountAddress::default(), Identifier::new("ChannelScript")?);
-
-                Ok(ScriptAction::new_call(
-                    module_id,
-                    Identifier::new("open")?,
-                    args,
-                ))
-            }
-            ChannelOp::Close => {
-                let module_id =
-                    ModuleId::new(AccountAddress::default(), Identifier::new("LibraAccount")?);
-
-                Ok(ScriptAction::new_call(
-                    module_id,
-                    Identifier::new("close")?,
-                    args,
-                ))
-            }
-            ChannelOp::Execute {
-                package_name,
-                script_name,
-            } => {
-                let script_code = self
-                    .script_registry
-                    .get_script(package_name, script_name)
-                    .ok_or(format_err!(
-                        "Can not find script by package {} and script name {}",
-                        package_name,
-                        script_name
-                    ))?;
-                Ok(ScriptAction::new_code(
-                    script_code.byte_code().clone(),
-                    args,
-                ))
-            }
-            ChannelOp::Action {
-                module_address,
-                module_name,
-                function_name,
-            } => {
-                let module_id = ModuleId::new(
-                    module_address.clone(),
-                    Identifier::new(module_name.clone().into_boxed_str())?,
-                );
-                Ok(ScriptAction::new_call(
-                    module_id,
-                    Identifier::new(function_name.clone().into_boxed_str())?,
-                    args,
-                ))
-            }
-        }
-    }
 }
 
-fn is_participant_channel_resource_modified(
+pub fn is_participant_channel_resource_modified(
     old_write_set: &WriteSet,
     new_write_set: &WriteSet,
     participant: &AccountAddress,

--- a/sgwallet/src/channel/channel.rs
+++ b/sgwallet/src/channel/channel.rs
@@ -324,7 +324,7 @@ impl Handler<ApplyPendingTxn> for Channel {
             ProposalLifecycle::Traveling => {
                 let channel_txn = &pending_txn.proposal().channel_txn;
                 if self.account_address() == &channel_txn.proposer() {
-                    let signed_txn = self.stm.build_channel_transaction_payload(&pending_txn)?;
+                    let signed_txn = self.stm.build_signed_txn(&pending_txn)?;
                     submit_transaction(self.chain_client.as_ref(), signed_txn).await?;
                 }
                 let txn_sender = channel_txn.proposer();

--- a/sgwallet/src/channel/channel_stm.rs
+++ b/sgwallet/src/channel/channel_stm.rs
@@ -1,0 +1,686 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    channel::{access_local, channel::is_participant_channel_resource_modified},
+    scripts::PackageRegistry,
+    wallet::{
+        execute_transaction, txn_expiration, GAS_UNIT_PRICE, MAX_GAS_AMOUNT_OFFCHAIN,
+        MAX_GAS_AMOUNT_ONCHAIN,
+    },
+    ChannelStateView,
+};
+use anyhow::{bail, ensure, format_err, Result};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
+    hash::CryptoHash,
+    test_utils::KeyPair,
+    HashValue, SigningKey, VerifyingKey,
+};
+use libra_logger::prelude::*;
+use libra_state_view::StateView;
+use libra_types::{
+    access_path::{AccessPath, DataPath},
+    account_address::AccountAddress,
+    channel::{
+        ChannelChallengeBy, ChannelLockedBy, ChannelMirrorResource,
+        ChannelParticipantAccountResource, ChannelResource, Witness, WitnessData,
+    },
+    identifier::Identifier,
+    language_storage::ModuleId,
+    libra_resource::{make_resource, LibraResource},
+    transaction::{
+        ChannelTransactionPayload, ChannelTransactionPayloadBody, RawTransaction, ScriptAction,
+        SignedTransaction, TransactionArgument, TransactionOutput, TransactionPayload,
+    },
+    write_set::WriteSet,
+};
+use serde::de::DeserializeOwned;
+use sgchain::star_chain_client::ChainClient;
+use sgtypes::{
+    channel::ChannelState,
+    channel_transaction::{ChannelOp, ChannelTransaction, ChannelTransactionProposal},
+    channel_transaction_sigs::ChannelTransactionSigs,
+    pending_txn::{PendingTransaction, ProposalLifecycle},
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    time::Duration,
+};
+use vm::gas_schedule::GasAlgebra;
+
+/// Channel State Machine has no internal mutable state.
+/// It is driven by `Channel`, so that we can mock channel state, and
+/// test the sender/receiver logic separately.
+/// Also, STM make more clear that what data is needed to make progress on channel state.   
+pub struct ChannelStm {
+    channel_address: AccountAddress,
+    account_address: AccountAddress,
+    // participant contains self address, use btree to preserve address order.
+    participant_addresses: BTreeSet<AccountAddress>,
+    participant_keys: BTreeMap<AccountAddress, Ed25519PublicKey>,
+    channel_state: ChannelState,
+    witness: Witness,
+
+    keypair: Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
+    script_registry: Arc<PackageRegistry>,
+    chain_client: Arc<dyn ChainClient>,
+}
+
+impl ChannelStm {
+    pub fn new(
+        channel_address: AccountAddress,
+        account_address: AccountAddress,
+        participant_addresses: BTreeSet<AccountAddress>,
+        participant_keys: BTreeMap<AccountAddress, Ed25519PublicKey>,
+        channel_state: ChannelState,
+        witness: Witness,
+
+        keypair: Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
+        script_registry: Arc<PackageRegistry>,
+        chain_client: Arc<dyn ChainClient>,
+    ) -> Self {
+        Self {
+            channel_address,
+            account_address,
+            participant_addresses,
+            participant_keys,
+            channel_state,
+            witness,
+            keypair,
+            script_registry,
+            chain_client,
+        }
+    }
+    fn get_local<T>(&self, access_path: &AccessPath) -> Result<Option<T>>
+    where
+        T: LibraResource + DeserializeOwned,
+    {
+        let data = access_local(self.witness.write_set(), &self.channel_state, access_path)?;
+        data.map(make_resource).transpose()
+    }
+
+    pub(crate) fn channel_sequence_number(&self) -> u64 {
+        let channel_mirror_resource = self
+            .get_local::<ChannelMirrorResource>(&AccessPath::new_for_data_path(
+                self.channel_address,
+                DataPath::channel_resource_path(
+                    self.channel_address,
+                    ChannelMirrorResource::struct_tag(),
+                ),
+            ))
+            .unwrap();
+        match channel_mirror_resource {
+            None => 0,
+            Some(r) => r.channel_sequence_number(),
+        }
+    }
+
+    pub(crate) fn channel_resource(&self) -> Option<ChannelResource> {
+        self.get_local::<ChannelResource>(&AccessPath::new_for_data_path(
+            self.channel_address,
+            DataPath::onchain_resource_path(ChannelResource::struct_tag()),
+        ))
+        .unwrap()
+    }
+    pub(crate) fn channel_lock_by_resource(&self) -> Option<ChannelLockedBy> {
+        self.get_local::<ChannelLockedBy>(&AccessPath::new_for_data_path(
+            self.channel_address,
+            DataPath::onchain_resource_path(ChannelLockedBy::struct_tag()),
+        ))
+        .unwrap()
+    }
+
+    #[allow(dead_code)]
+    fn channel_challenge_by_resource(&self) -> Option<ChannelChallengeBy> {
+        self.get_local::<ChannelChallengeBy>(&AccessPath::new_for_data_path(
+            self.channel_address,
+            DataPath::onchain_resource_path(ChannelChallengeBy::struct_tag()),
+        ))
+        .unwrap()
+    }
+
+    #[allow(dead_code)]
+    fn channel_account_resource(&self) -> Option<ChannelParticipantAccountResource> {
+        self.get_local::<ChannelParticipantAccountResource>(&AccessPath::new_for_data_path(
+            self.channel_address,
+            DataPath::channel_resource_path(
+                self.account_address,
+                ChannelParticipantAccountResource::struct_tag(),
+            ),
+        ))
+        .unwrap()
+    }
+
+    pub(crate) fn channel_state(&self) -> &ChannelState {
+        &self.channel_state
+    }
+    pub(crate) fn witness(&self) -> &Witness {
+        &self.witness
+    }
+
+    pub fn advance_state(
+        &mut self,
+        channel_state: Option<ChannelState>,
+        witness: Witness,
+        mut participant_keys: BTreeMap<AccountAddress, Ed25519PublicKey>,
+    ) {
+        if let Some(cs) = channel_state {
+            self.channel_state = cs;
+        }
+        self.witness = witness;
+        self.participant_keys.append(&mut participant_keys);
+    }
+
+    //    fn check_applied(
+    //        &self,
+    //        channel_sequence_number: u64,
+    //    ) -> Result<Option<(SignedChannelTransactionWithProof)>> {
+    //        if let Some(info) = self.store.get_startup_info()? {
+    //            if channel_sequence_number > info.latest_version {
+    //                Ok(None)
+    //            } else {
+    //                let signed_channel_txn_with_proof = self
+    //                    .store
+    //                    .get_transaction_by_channel_seq_number(channel_sequence_number, false)?;
+    //                debug_assert_eq!(
+    //                    signed_channel_txn_with_proof.version,
+    //                    channel_sequence_number
+    //                );
+    //                Ok(Some(signed_channel_txn_with_proof))
+    //            }
+    //        } else {
+    //            Ok(None)
+    //        }
+    //    }
+    //
+    pub fn handle_new_proposal(
+        &self,
+        pending_txn: &mut Option<PendingTransaction>,
+        proposal: ChannelTransactionProposal,
+    ) -> Result<()> {
+        if proposal.channel_txn.channel_sequence_number() < self.channel_sequence_number() {
+            bail!("invalid channel proposal, proposal channel_sequence_number {} < local channel_sequence_number {}",proposal.channel_txn.channel_sequence_number(), self.channel_sequence_number());
+        }
+        match pending_txn {
+            None => {
+                // TODO: if I propose this, don't verify.
+                self.verify_proposal(&proposal)?;
+
+                debug!(
+                    "{} - execute proposal: {}, {:?}",
+                    &self.account_address,
+                    proposal.channel_txn.operator(),
+                    proposal.channel_txn.args()
+                );
+                // execute proposal to get txn payload and txn witness data for later use
+                let (_payload_body, _payload_body_signature, output) =
+                    self.execute_proposal(&proposal)?;
+
+                let mut p = PendingTransaction::new(proposal, output, BTreeMap::new());
+                p.set_lifecycle(ProposalLifecycle::Created);
+                *pending_txn = Some(p);
+            }
+            Some(pending) => {
+                if CryptoHash::hash(&pending.proposal().channel_txn)
+                    != CryptoHash::hash(&proposal.channel_txn)
+                {
+                    bail!(
+                        "already exists a different pending proposal, op: {}",
+                        pending.proposal().channel_txn.operator()
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn handle_proposal_signature(
+        &self,
+        //        proposal: ChannelTransactionProposal,
+        pending_txn: &mut PendingTransaction,
+        proposal_id: HashValue,
+        sigs: ChannelTransactionSigs,
+    ) -> Result<()> {
+        let proposal_lifecycle = pending_txn.lifecycle();
+        //        let (proposal, output, mut signatures) = pending_txn.into();
+        let proposal = pending_txn.proposal();
+        ensure!(
+            proposal.channel_txn.hash() == proposal_id,
+            "proposal txn hash mismatched"
+        );
+
+        if pending_txn.get_signature(&sigs.address).is_none() {
+            let (payload_body, _) =
+                self.build_and_sign_channel_txn_payload_body(&proposal.channel_txn)?;
+            self.verify_txn_sigs(&payload_body, pending_txn.output(), &sigs)?;
+            pending_txn.add_signature(sigs);
+
+            match proposal_lifecycle {
+                ProposalLifecycle::Created => {
+                    pending_txn.set_lifecycle(ProposalLifecycle::Negotiating);
+                }
+                ProposalLifecycle::Negotiating => {
+                    pending_txn.try_reach_consensus(&self.participant_addresses);
+                }
+                _ => unreachable!(),
+            }
+        }
+        return Ok(());
+    }
+    pub fn handle_apply_proposal(&self, pending_txn: &mut PendingTransaction) -> Result<()> {
+        let can_be_offchain =
+            pending_txn.consensus_reached() && !pending_txn.output().is_travel_txn();
+        if can_be_offchain {
+            // can directly apply offchain
+            pending_txn.set_applying();
+        } else {
+            pending_txn.set_travelling();
+        }
+        Ok(())
+    }
+
+    pub fn can_auto_sign_pending_proposal(&self, pending_txn: &PendingTransaction) -> Result<bool> {
+        let can_auto_signed = !is_participant_channel_resource_modified(
+            self.witness.write_set(),
+            pending_txn.output().write_set(),
+            &self.account_address,
+        );
+        Ok(can_auto_signed)
+    }
+
+    /// build channel txn payload version 2.
+    fn build_and_sign_channel_txn_payload_body(
+        &self,
+        channel_txn: &ChannelTransaction,
+    ) -> Result<(ChannelTransactionPayloadBody, Ed25519Signature)> {
+        let action =
+            self.channel_op_to_action(channel_txn.operator(), channel_txn.args().to_vec())?;
+
+        let body = ChannelTransactionPayloadBody::new(
+            self.channel_address,
+            channel_txn.proposer(),
+            action,
+            self.witness.clone(),
+        );
+        let body_hash = CryptoHash::hash(&body);
+        let sig = self.keypair.private_key.sign_message(&body_hash);
+        Ok((body, sig))
+    }
+
+    pub fn build_channel_transaction_payload(
+        &self,
+        pending_txn: &PendingTransaction,
+    ) -> Result<SignedTransaction> {
+        let channel_txn = &pending_txn.proposal().channel_txn;
+
+        let (payload_body, _payload_signature) =
+            self.build_and_sign_channel_txn_payload_body(channel_txn)?;
+        let max_gas_amount = std::cmp::min(
+            (pending_txn.output().gas_used() as f64 * 1.1) as u64,
+            MAX_GAS_AMOUNT_ONCHAIN,
+        );
+        let signed_txn = self.build_raw_txn_from_channel_txn(
+            payload_body,
+            channel_txn,
+            Some(pending_txn.signatures()),
+            max_gas_amount,
+        )?;
+        Ok(signed_txn)
+    }
+
+    fn build_raw_txn_from_channel_txn(
+        &self,
+        channel_payload_body: ChannelTransactionPayloadBody,
+        channel_txn: &ChannelTransaction,
+        txn_signatures: Option<&BTreeMap<AccountAddress, ChannelTransactionSigs>>,
+        max_gas_amount: u64,
+    ) -> Result<SignedTransaction> {
+        let channel_payload_signatures = txn_signatures.map(|s| {
+            s.into_iter()
+                .map(|(k, v)| {
+                    let ChannelTransactionSigs {
+                        public_key,
+                        channel_payload_signature,
+                        ..
+                    } = v;
+                    (
+                        k.clone(),
+                        (public_key.clone(), channel_payload_signature.clone()),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>()
+        });
+        self.build_chain_txn(
+            channel_payload_body,
+            channel_payload_signatures,
+            channel_txn.proposer(),
+            channel_txn.sequence_number(),
+            max_gas_amount,
+            channel_txn.expiration_time(),
+        )
+    }
+    fn build_chain_txn(
+        &self,
+        channel_payload_body: ChannelTransactionPayloadBody,
+        txn_signatures: Option<BTreeMap<AccountAddress, (Ed25519PublicKey, Ed25519Signature)>>,
+        txn_sender: AccountAddress,
+        sender_seq_number: u64,
+        max_gas_amount: u64,
+        expiration_time: Duration,
+    ) -> Result<SignedTransaction> {
+        let channel_participant_size = self.participant_addresses.len();
+        let mut participant_keys = self.participant_keys.clone();
+        let mut sigs = Vec::with_capacity(channel_participant_size);
+        if let Some(signatures) = txn_signatures {
+            for addr in self.participant_addresses.iter() {
+                let sig = signatures.get(&addr);
+                if let Some(s) = sig {
+                    participant_keys.insert(addr.clone(), s.0.clone());
+                }
+                sigs.push(sig.map(|s| s.1.clone()));
+            }
+        }
+
+        if channel_payload_body.witness().channel_sequence_number() == 0 {
+            //            debug_assert!(channel_txn.operator().is_open());
+        } else {
+            debug_assert!(channel_participant_size == participant_keys.len());
+        }
+
+        let keys = participant_keys
+            .into_iter()
+            .map(|p| p.1)
+            .collect::<Vec<_>>();
+
+        let channel_txn_payload = ChannelTransactionPayload::new(channel_payload_body, keys, sigs);
+        let txn_payload = TransactionPayload::Channel(channel_txn_payload);
+
+        let raw_txn = RawTransaction::new(
+            txn_sender,
+            sender_seq_number,
+            txn_payload,
+            max_gas_amount,
+            GAS_UNIT_PRICE,
+            expiration_time,
+        );
+        Ok(raw_txn
+            .sign(&self.keypair.private_key, self.keypair.public_key.clone())?
+            .into_inner())
+    }
+
+    fn channel_op_to_action(
+        &self,
+        op: &ChannelOp,
+        args: Vec<TransactionArgument>,
+    ) -> Result<ScriptAction> {
+        match op {
+            ChannelOp::Open => {
+                let module_id =
+                    ModuleId::new(AccountAddress::default(), Identifier::new("ChannelScript")?);
+
+                Ok(ScriptAction::new_call(
+                    module_id,
+                    Identifier::new("open")?,
+                    args,
+                ))
+            }
+            ChannelOp::Close => {
+                let module_id =
+                    ModuleId::new(AccountAddress::default(), Identifier::new("LibraAccount")?);
+
+                Ok(ScriptAction::new_call(
+                    module_id,
+                    Identifier::new("close")?,
+                    args,
+                ))
+            }
+            ChannelOp::Execute {
+                package_name,
+                script_name,
+            } => {
+                let script_code = self
+                    .script_registry
+                    .get_script(package_name, script_name)
+                    .ok_or(format_err!(
+                        "Can not find script by package {} and script name {}",
+                        package_name,
+                        script_name
+                    ))?;
+                Ok(ScriptAction::new_code(
+                    script_code.byte_code().clone(),
+                    args,
+                ))
+            }
+            ChannelOp::Action {
+                module_address,
+                module_name,
+                function_name,
+            } => {
+                let module_id = ModuleId::new(
+                    module_address.clone(),
+                    Identifier::new(module_name.clone().into_boxed_str())?,
+                );
+                Ok(ScriptAction::new_call(
+                    module_id,
+                    Identifier::new(function_name.clone().into_boxed_str())?,
+                    args,
+                ))
+            }
+        }
+    }
+
+    pub fn generate_proposal(
+        &self,
+        channel_op: ChannelOp,
+        args: Vec<TransactionArgument>,
+    ) -> Result<ChannelTransactionProposal> {
+        // TODO: state view should be shared to reduce fetching account state from layer1.
+        let state_view = self.channel_view(None)?;
+
+        // account state already cached in state view
+        let account_seq_number = {
+            let account_resource_blob = state_view
+                .get(&AccessPath::new_for_account_resource(self.account_address))?
+                .ok_or(format_err!(
+                    "account resource for {} not exists on chain",
+                    self.account_address,
+                ))?;
+            let account_resource =
+                sgtypes::account_resource_ext::from_bytes(&account_resource_blob)?;
+            account_resource.sequence_number()
+        };
+
+        let chain_version = state_view.version();
+        // build channel_transaction first
+        let channel_txn = ChannelTransaction::new(
+            chain_version,
+            self.channel_address,
+            self.channel_sequence_number(),
+            channel_op,
+            args,
+            self.account_address,
+            account_seq_number,
+            txn_expiration(),
+        );
+        let channel_txn_hash = CryptoHash::hash(&channel_txn);
+        let channel_txn_signature = self.keypair.private_key.sign_message(&channel_txn_hash);
+
+        let proposal = ChannelTransactionProposal {
+            channel_txn,
+            proposer_public_key: self.keypair.public_key.clone(),
+            proposer_signature: channel_txn_signature,
+        };
+        Ok(proposal)
+    }
+
+    pub fn execute_proposal(
+        &self,
+        proposal: &ChannelTransactionProposal,
+    ) -> Result<(
+        ChannelTransactionPayloadBody,
+        Ed25519Signature,
+        TransactionOutput,
+    )> {
+        let channel_txn = &proposal.channel_txn;
+        let (payload_body, payload_body_signature) =
+            self.build_and_sign_channel_txn_payload_body(channel_txn)?;
+
+        let output = {
+            // create mocked txn to execute
+            // execute txn on offchain vm, should mock sender and receiver signature with a local
+            // keypair. the vm will skip signature check on offchain vm.
+            let txn = self.build_raw_txn_from_channel_txn(
+                payload_body.clone(),
+                channel_txn,
+                None,
+                MAX_GAS_AMOUNT_OFFCHAIN,
+            )?;
+
+            let version = channel_txn.version();
+            let state_view = self.channel_view(Some(version))?;
+            execute_transaction(&state_view, txn)?
+        };
+
+        // check output gas
+        let gas_used = output.gas_used();
+        if gas_used > vm::gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS.get() {
+            warn!(
+                "GasUsed {} > gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS {}",
+                gas_used,
+                vm::gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS.get()
+            );
+        }
+
+        Ok((payload_body, payload_body_signature, output))
+    }
+
+    pub fn generate_txn_sigs(
+        &self,
+        channel_txn: &ChannelTransaction,
+        output: &TransactionOutput,
+    ) -> Result<ChannelTransactionSigs> {
+        let (_, payload_body_signature) =
+            self.build_and_sign_channel_txn_payload_body(channel_txn)?;
+
+        let ws = if output.is_travel_txn() {
+            WriteSet::default()
+        } else {
+            output.write_set().clone()
+        };
+        let witness_data = WitnessData::new(self.channel_sequence_number() + 1, ws);
+        let witness_data_hash = CryptoHash::hash(&witness_data);
+        let witness_data_signature = self.keypair.private_key.sign_message(&witness_data_hash);
+
+        let travel_output_witness_signature = if output.is_travel_txn() {
+            let txn_output_witness_data = WitnessData::new(
+                self.channel_sequence_number() + 1,
+                output.write_set().clone(),
+            );
+            Some(
+                self.keypair
+                    .private_key
+                    .sign_message(&CryptoHash::hash(&txn_output_witness_data)),
+            )
+        } else {
+            None
+        };
+
+        let generated_sigs = ChannelTransactionSigs::new(
+            self.account_address,
+            self.keypair.public_key.clone(),
+            payload_body_signature,
+            witness_data_hash,
+            witness_data_signature,
+            travel_output_witness_signature,
+        );
+
+        Ok(generated_sigs)
+    }
+
+    fn verify_proposal(&self, proposal: &ChannelTransactionProposal) -> Result<()> {
+        let channel_txn = &proposal.channel_txn;
+        ensure!(
+            self.channel_address == channel_txn.channel_address(),
+            "invalid channel address"
+        );
+        let channel_sequence_number = self.channel_sequence_number();
+        let smallest_allowed_channel_seq_number =
+            channel_sequence_number.checked_sub(1).unwrap_or(0);
+        ensure!(
+            channel_txn.channel_sequence_number() >= smallest_allowed_channel_seq_number
+                && channel_txn.channel_sequence_number() <= channel_sequence_number,
+            "check channel_sequence_number fail."
+        );
+        proposal
+            .proposer_public_key
+            .verify_signature(&CryptoHash::hash(channel_txn), &proposal.proposer_signature)?;
+
+        // TODO: check public key match proposer address
+        if !channel_txn.operator().is_open() {
+            ensure!(
+                self.participant_addresses.contains(&channel_txn.proposer()),
+                "proposer does not belong to the channel"
+            );
+        }
+        Ok(())
+    }
+
+    fn verify_txn_sigs(
+        &self,
+        payload_body: &ChannelTransactionPayloadBody,
+        output: &TransactionOutput,
+        channel_txn_sigs: &ChannelTransactionSigs,
+    ) -> Result<()> {
+        channel_txn_sigs.public_key.verify_signature(
+            &CryptoHash::hash(payload_body),
+            &channel_txn_sigs.channel_payload_signature,
+        )?;
+
+        let ws = if output.is_travel_txn() {
+            WriteSet::default()
+        } else {
+            output.write_set().clone()
+        };
+        let witness_data = WitnessData::new(self.channel_sequence_number() + 1, ws);
+
+        ensure!(
+            &CryptoHash::hash(&witness_data) == &channel_txn_sigs.witness_data_hash,
+            "witness hash mismatched"
+        );
+        channel_txn_sigs.public_key.verify_signature(
+            &channel_txn_sigs.witness_data_hash,
+            &channel_txn_sigs.witness_data_signature,
+        )?;
+
+        if output.is_travel_txn() {
+            match &channel_txn_sigs.travel_output_witness_signature {
+                None => bail!("travel txn should have signer's signature on output"),
+                Some(signature) => {
+                    let txn_output_witness_data = WitnessData::new(
+                        self.channel_sequence_number() + 1,
+                        output.write_set().clone(),
+                    );
+                    channel_txn_sigs
+                        .public_key
+                        .verify_signature(&CryptoHash::hash(&txn_output_witness_data), signature)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn channel_view(&self, version: Option<u64>) -> Result<ChannelStateView> {
+        // TODO: reduce clone
+        let latest_writeset = self.witness.clone().into_write_set();
+        ChannelStateView::new(
+            self.account_address,
+            &self.channel_state,
+            latest_writeset,
+            version,
+            self.chain_client.as_ref(),
+        )
+    }
+}

--- a/sgwallet/src/channel/channel_stm.rs
+++ b/sgwallet/src/channel/channel_stm.rs
@@ -287,10 +287,7 @@ impl ChannelStm {
         Ok((body, sig))
     }
 
-    pub fn build_channel_transaction_payload(
-        &self,
-        pending_txn: &PendingTransaction,
-    ) -> Result<SignedTransaction> {
+    pub fn build_signed_txn(&self, pending_txn: &PendingTransaction) -> Result<SignedTransaction> {
         let channel_txn = &pending_txn.proposal().channel_txn;
 
         let (payload_body, _payload_signature) =
@@ -651,12 +648,10 @@ impl ChannelStm {
     }
 
     fn channel_view(&self, version: Option<u64>) -> Result<ChannelStateView> {
-        // TODO: reduce clone
-        let latest_writeset = self.witness.clone().into_write_set();
         ChannelStateView::new(
             self.account_address,
             &self.channel_state,
-            latest_writeset,
+            self.witness.write_set(),
             version,
             self.chain_client.as_ref(),
         )

--- a/sgwallet/src/channel/channel_stm.rs
+++ b/sgwallet/src/channel/channel_stm.rs
@@ -55,10 +55,10 @@ use vm::gas_schedule::GasAlgebra;
 /// test the sender/receiver logic separately.
 /// Also, STM make more clear that what data is needed to make progress on channel state.   
 pub struct ChannelStm {
-    channel_address: AccountAddress,
-    account_address: AccountAddress,
+    pub(crate) channel_address: AccountAddress,
+    pub(crate) account_address: AccountAddress,
     // participant contains self address, use btree to preserve address order.
-    participant_addresses: BTreeSet<AccountAddress>,
+    pub(crate) participant_addresses: BTreeSet<AccountAddress>,
     participant_keys: BTreeMap<AccountAddress, Ed25519PublicKey>,
     channel_state: ChannelState,
     witness: Witness,
@@ -173,28 +173,6 @@ impl ChannelStm {
         self.participant_keys.append(&mut participant_keys);
     }
 
-    //    fn check_applied(
-    //        &self,
-    //        channel_sequence_number: u64,
-    //    ) -> Result<Option<(SignedChannelTransactionWithProof)>> {
-    //        if let Some(info) = self.store.get_startup_info()? {
-    //            if channel_sequence_number > info.latest_version {
-    //                Ok(None)
-    //            } else {
-    //                let signed_channel_txn_with_proof = self
-    //                    .store
-    //                    .get_transaction_by_channel_seq_number(channel_sequence_number, false)?;
-    //                debug_assert_eq!(
-    //                    signed_channel_txn_with_proof.version,
-    //                    channel_sequence_number
-    //                );
-    //                Ok(Some(signed_channel_txn_with_proof))
-    //            }
-    //        } else {
-    //            Ok(None)
-    //        }
-    //    }
-    //
     pub fn handle_new_proposal(
         &self,
         pending_txn: &mut Option<PendingTransaction>,

--- a/sgwallet/src/channel/mod.rs
+++ b/sgwallet/src/channel/mod.rs
@@ -35,10 +35,6 @@ mod channel_handle;
 mod channel_stm;
 
 pub struct Channel {
-    channel_address: AccountAddress,
-    account_address: AccountAddress,
-    // participant contains self address, use btree to preserve address order.
-    participant_addresses: BTreeSet<AccountAddress>,
     store: ChannelStore<ChannelDB>,
     chain_client: Arc<dyn ChainClient>,
     tx_applier: TxApplier,
@@ -78,9 +74,6 @@ impl Channel {
             chain_client.clone(),
         );
         let inner = Self {
-            channel_address,
-            account_address,
-            participant_addresses: participant_addresses.clone(),
             store: store.clone(),
             chain_client: chain_client.clone(),
             tx_applier: TxApplier::new(store.clone()),
@@ -92,9 +85,9 @@ impl Channel {
     }
 
     pub async fn start(self, mut context: ActorContext) -> ChannelHandle {
-        let channel_address = self.channel_address;
-        let account_address = self.account_address;
-        let participant_addresses = self.participant_addresses.clone();
+        let channel_address = self.channel_address().clone();
+        let account_address = self.account_address().clone();
+        let participant_addresses = self.participant_addresses().clone();
 
         let actor_ref = context
             .new_actor(self)
@@ -107,6 +100,16 @@ impl Channel {
             participant_addresses,
             actor_ref,
         )
+    }
+
+    pub fn channel_address(&self) -> &AccountAddress {
+        &self.stm.channel_address
+    }
+    pub fn account_address(&self) -> &AccountAddress {
+        &self.stm.account_address
+    }
+    pub fn participant_addresses(&self) -> &BTreeSet<AccountAddress> {
+        &self.stm.participant_addresses
     }
 }
 

--- a/sgwallet/src/channel/mod.rs
+++ b/sgwallet/src/channel/mod.rs
@@ -5,6 +5,8 @@ use crate::{chain_watcher::ChainWatcherHandle, scripts::PackageRegistry, tx_appl
 use anyhow::{bail, Result};
 use coerce_rt::actor::{context::ActorContext, message::Message, ActorRef};
 
+use crate::{channel::channel_stm::ChannelStm, wallet::Wallet};
+pub use channel_handle::ChannelHandle;
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     test_utils::KeyPair,
@@ -13,7 +15,8 @@ use libra_crypto::{
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    transaction::{TransactionArgument, TransactionOutput},
+    contract_event::ContractEvent,
+    transaction::{Transaction, TransactionArgument, TransactionInfo, TransactionOutput},
     write_set::{WriteOp, WriteSet},
 };
 use sgchain::star_chain_client::ChainClient;
@@ -29,22 +32,14 @@ use std::{collections::BTreeSet, sync::Arc};
 mod channel;
 mod channel_event_stream;
 mod channel_handle;
-use crate::wallet::Wallet;
-pub use channel_handle::ChannelHandle;
-use libra_types::{
-    contract_event::ContractEvent,
-    transaction::{Transaction, TransactionInfo},
-};
+mod channel_stm;
 
 pub struct Channel {
     channel_address: AccountAddress,
     account_address: AccountAddress,
     // participant contains self address, use btree to preserve address order.
     participant_addresses: BTreeSet<AccountAddress>,
-    channel_state: ChannelState,
     store: ChannelStore<ChannelDB>,
-    keypair: Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
-    script_registry: Arc<PackageRegistry>,
     chain_client: Arc<dyn ChainClient>,
     tx_applier: TxApplier,
 
@@ -53,6 +48,7 @@ pub struct Channel {
 
     // watch onchain channel txn of this channel
     chain_txn_watcher: ChainWatcherHandle,
+    stm: ChannelStm,
 }
 impl Channel {
     /// load channel from storage
@@ -70,18 +66,27 @@ impl Channel {
     ) -> Self {
         let store = ChannelStore::new(participant_addresses.clone(), db.clone())
             .unwrap_or_else(|e| panic!("create channel store should be ok, e: {}", e));
+        let stm = ChannelStm::new(
+            channel_address.clone(),
+            account_address.clone(),
+            participant_addresses.clone(),
+            store.get_participant_keys(),
+            channel_state.clone(),
+            store.get_latest_witness().unwrap_or_default(),
+            keypair.clone(),
+            script_registry.clone(),
+            chain_client.clone(),
+        );
         let inner = Self {
             channel_address,
             account_address,
             participant_addresses: participant_addresses.clone(),
-            channel_state,
             store: store.clone(),
-            keypair: keypair.clone(),
-            script_registry: script_registry.clone(),
             chain_client: chain_client.clone(),
             tx_applier: TxApplier::new(store.clone()),
             channel_event_sender: supervisor_ref,
             chain_txn_watcher,
+            stm,
         };
         inner
     }
@@ -126,10 +131,9 @@ impl Message for CollectProposalWithSigs {
 }
 pub(crate) struct GrantProposal {
     pub channel_txn_id: HashValue,
-    pub grant: bool,
 }
 impl Message for GrantProposal {
-    type Result = Result<Option<ChannelTransactionSigs>>;
+    type Result = Result<ChannelTransactionSigs>;
 }
 pub(crate) struct CancelPendingTxn {
     pub channel_txn_id: HashValue,
@@ -137,9 +141,7 @@ pub(crate) struct CancelPendingTxn {
 impl Message for CancelPendingTxn {
     type Result = Result<()>;
 }
-pub(crate) struct ApplyPendingTxn {
-    pub proposal: ChannelTransactionProposal,
-}
+pub(crate) struct ApplyPendingTxn;
 /// return a (sender, seq_number) txn to watch if travel.
 impl Message for ApplyPendingTxn {
     type Result = Result<Option<(AccountAddress, u64)>>;
@@ -166,10 +168,6 @@ impl Message for ApplyCoSignedTxn {
     type Result = Result<u64>;
 }
 
-pub(crate) struct ForceTravel;
-impl Message for ForceTravel {
-    type Result = Result<(AccountAddress, u64)>;
-}
 pub(crate) struct GetPendingTxn;
 impl Message for GetPendingTxn {
     type Result = Option<PendingTransaction>;

--- a/sgwallet/src/channel_state_view.rs
+++ b/sgwallet/src/channel_state_view.rs
@@ -11,7 +11,7 @@ use sgtypes::channel::ChannelState;
 
 pub struct ChannelStateView<'txn> {
     channel_state: &'txn ChannelState,
-    latest_write_set: WriteSet,
+    latest_write_set: &'txn WriteSet,
     client_state_view: ClientStateView<'txn>,
 }
 
@@ -19,7 +19,7 @@ impl<'txn> ChannelStateView<'txn> {
     pub fn new(
         account_address: AccountAddress,
         channel_state: &'txn ChannelState,
-        latest_write_set: WriteSet,
+        latest_write_set: &'txn WriteSet,
         version: Option<Version>,
         client: &'txn dyn ChainClient,
     ) -> Result<Self> {
@@ -47,7 +47,7 @@ impl<'txn> ChannelStateView<'txn> {
 
     pub fn get_local(&self, access_path: &AccessPath) -> Result<Option<Vec<u8>>> {
         let d =
-            super::channel::access_local(&self.latest_write_set, self.channel_state, access_path)?;
+            super::channel::access_local(self.latest_write_set, self.channel_state, access_path)?;
         Ok(d.map(|t| t.to_vec()))
     }
 }

--- a/sgwallet/src/utils/contract.rs
+++ b/sgwallet/src/utils/contract.rs
@@ -17,15 +17,17 @@ lazy_static! {
     static ref CLOSE_METHOD_NAME: Identifier = Identifier::new("close").unwrap();
 }
 
-fn channel_challenge_name() -> &'static IdentStr {
+pub fn channel_challenge_name() -> &'static IdentStr {
     &*CHALLENGE_METHOD_NAME
 }
-fn channel_resolve_name() -> &'static IdentStr {
+pub fn channel_resolve_name() -> &'static IdentStr {
     &*RESOLVE_METHOD_NAME
 }
-fn channel_close_name() -> &'static IdentStr {
+pub fn channel_close_name() -> &'static IdentStr {
     &*CLOSE_METHOD_NAME
 }
+
+#[allow(dead_code)]
 pub fn resolve_channel_action() -> ScriptAction {
     ScriptAction::new_call(
         ModuleId::new(core_code_address(), account_module_name().into()),
@@ -33,7 +35,7 @@ pub fn resolve_channel_action() -> ScriptAction {
         vec![],
     )
 }
-
+#[allow(dead_code)]
 pub fn challenge_channel_action() -> ScriptAction {
     ScriptAction::new_call(
         ModuleId::new(core_code_address(), account_module_name().into()),
@@ -42,6 +44,7 @@ pub fn challenge_channel_action() -> ScriptAction {
     )
 }
 
+#[allow(dead_code)]
 pub fn close_channel_action(violator: AccountAddress) -> ScriptAction {
     ScriptAction::new_call(
         ModuleId::new(core_code_address(), account_module_name().into()),

--- a/sgwallet/tests/common/mod.rs
+++ b/sgwallet/tests/common/mod.rs
@@ -224,9 +224,9 @@ pub async fn transfer(
     let sender_gas_used = sender_wallet
         .apply_txn(receiver, &receiver_transfer_txn)
         .await?;
-    let _ = receiver_wallet
-        .apply_txn(sender, &receiver_transfer_txn)
-        .await?;
+    //    let _ = receiver_wallet
+    //        .apply_txn(sender, &receiver_transfer_txn)
+    //        .await?;
     Ok(sender_gas_used)
 }
 

--- a/sgwallet/tests/test_chain_watcher.rs
+++ b/sgwallet/tests/test_chain_watcher.rs
@@ -42,7 +42,7 @@ fn run_test_chain_watcher(chain_client: Arc<dyn ChainClient>) -> Result<()> {
         let mut actor_ref = actor_context.new_actor(chain_state_accessor).await?;
 
         let mut receiver = chain_watcher_handle
-            .add_interest("test".to_string().into_bytes(), Box::new(|_txn| true))
+            .add_interest(Box::new(|_txn| true))
             .await?;
         let account_address = AccountAddress::random();
         chain_client.faucet(account_address, 10000).await?;

--- a/sgwallet/tests/test_channel_challenge.rs
+++ b/sgwallet/tests/test_channel_challenge.rs
@@ -115,10 +115,7 @@ async fn test_channel_lock_and_resolve(
     let channel_address = sender_channel_handle_clone.channel_address().clone();
 
     let channel_txn_receiver = chain_watcher_handle
-        .add_interest_oneshot(
-            sender.account().to_vec(),
-            channel_txn_interest_oneshot(channel_address, 3),
-        )
+        .add_interest_oneshot(channel_txn_interest_oneshot(channel_address, 3))
         .await?;
     let txn_with_info: TransactionWithInfo = channel_txn_receiver.await?;
     let _resolve_txn_version = txn_with_info.version;
@@ -183,10 +180,7 @@ async fn test_channel_lock_and_challenge(
 
     let channel_address = sender_channel_handle.channel_address().clone();
     let channel_txn_receiver = chain_watcher_handle
-        .add_interest_oneshot(
-            sender.account().to_vec(),
-            channel_txn_interest_oneshot(channel_address, 3),
-        )
+        .add_interest_oneshot(channel_txn_interest_oneshot(channel_address, 3))
         .await?;
     let txn_with_info: TransactionWithInfo = channel_txn_receiver.await?;
     let channel_state = sender
@@ -246,10 +240,7 @@ async fn test_channel_lock_and_timeout(
     // wait timeout and close channel
     let channel_address = sender_channel_handle.channel_address().clone();
     let channel_txn_receiver = chain_watcher_handle
-        .add_interest_oneshot(
-            sender.account().to_vec(),
-            channel_txn_interest_oneshot(channel_address, 3),
-        )
+        .add_interest_oneshot(channel_txn_interest_oneshot(channel_address, 3))
         .await?;
     let txn_with_info: TransactionWithInfo = channel_txn_receiver.await?;
     let channel_state = sender

--- a/sgwallet/tests/wallet_test_by_mock_chain.rs
+++ b/sgwallet/tests/wallet_test_by_mock_chain.rs
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use libra_logger::prelude::*;
 use libra_types::transaction::TransactionArgument;
 use mock_chain_test_helper::run_with_mock_client;
-
 use sgtypes::script_package::ChannelScriptPackage;
-
 use wallet_test_helper::{
     deploy_custom_module_and_script, test_deploy_custom_module, test_wallet_async,
 };
@@ -22,7 +21,7 @@ fn test_wallet_with_mock_client() {
             rt.block_on(test_wallet_async(sender, receiver))
         })
     }) {
-        println!("err: {:?}", e);
+        error!("err: {:#?}", e);
         assert!(false)
     }
 }


### PR DESCRIPTION
This PR move channel transaction request interaction into a state machine.
The STM reacts to several actions based on some channel state, and the channel state is driven by çaller who is responsible to save pending requests, and apply states.
This will make channel txn request interaction easy to test without to touch storage.

Also, the challenge/resolve logic is unified. the handler of force travel channel txn is also used to handle challenge/resolve.